### PR TITLE
Fix indentation for init_db initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ def create_app() -> Flask:
     # Inizializza il database una volta all’avvio utilizzando il contesto dell’applicazione.
     # In Flask 3.x il decorator before_first_request non è più disponibile.
     with app.app_context():
-    init_db()
+        init_db()
 
 
     # Rotta principale: mostra un riepilogo dei conteggi


### PR DESCRIPTION
## Summary
- indent the init_db call within the app context block to ensure it runs when the application context is active

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de2b94ce0c832d8b05a56307a70a31