### PR TITLE
Add template layout and configure Flask app initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,19 +17,19 @@ def create_app() -> Flask:
     """Factory per creare e configurare l'istanza di Flask."""
     app = Flask(__name__, instance_relative_config=True)
     # Chiave segreta per il sistema di messaggistica flash
-    app.config.setdefault('SECRET_KEY', 'change-me-please')
+    app.config['SECRET_KEY'] = 'change-me-please'
     # Percorso del database: per default è nella stessa directory del file app
     app.config.setdefault('DATABASE', str(Path(app.root_path) / 'database.db'))
 
     # Chiude la connessione al database alla fine di ogni richiesta
     @app.teardown_appcontext
     def _close_database(exception: Optional[BaseException] = None):
-       close_db(exception)
+        close_db(exception)
 
     # Inizializza il database una volta all’avvio utilizzando il contesto dell’applicazione.
     # In Flask 3.x il decorator before_first_request non è più disponibile.
     with app.app_context():
-    init_db()
+        init_db()
 
 
     # Rotta principale: mostra un riepilogo dei conteggi
@@ -178,7 +178,9 @@ def create_app() -> Flask:
     return app
 
 
+app = create_app()
+
+
 if __name__ == '__main__':
-    app = create_app()
     # Avvia il server di sviluppo
     app.run(debug=True)

--- a/templates/add_customer.html
+++ b/templates/add_customer.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Nuovo cliente{% endblock %}
+{% block content %}
+<h2>Aggiungi cliente</h2>
+<form method="post">
+    <label for="name">Nome *</label>
+    <input type="text" id="name" name="name" required>
+
+    <label for="email">Email</label>
+    <input type="email" id="email" name="email">
+
+    <label for="phone">Telefono</label>
+    <input type="text" id="phone" name="phone">
+
+    <label for="address">Indirizzo</label>
+    <textarea id="address" name="address" rows="3"></textarea>
+
+    <button type="submit">Salva</button>
+</form>
+{% endblock %}

--- a/templates/add_repair.html
+++ b/templates/add_repair.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block title %}Nuova riparazione{% endblock %}
+{% block content %}
+<h2>Registra riparazione</h2>
+<form method="post">
+    <label for="ticket_id">Ticket *</label>
+    <select id="ticket_id" name="ticket_id" required>
+        <option value="">-- seleziona --</option>
+        {% for ticket in tickets %}
+        {% set selected = request.args.get('ticket_id') == ticket['id']|string %}
+        <option value="{{ ticket['id'] }}" {% if selected %}selected{% endif %}>{{ ticket['subject'] }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="product">Prodotto</label>
+    <input type="text" id="product" name="product">
+
+    <label for="issue_description">Descrizione problema</label>
+    <textarea id="issue_description" name="issue_description" rows="4"></textarea>
+
+    <label for="repair_status">Stato riparazione</label>
+    <select id="repair_status" name="repair_status">
+        <option value="pending">In attesa</option>
+        <option value="in_progress">In lavorazione</option>
+        <option value="completed">Completata</option>
+    </select>
+
+    <label for="date_received">Data ricezione</label>
+    <input type="date" id="date_received" name="date_received">
+
+    <label for="date_repaired">Data riparazione</label>
+    <input type="date" id="date_repaired" name="date_repaired">
+
+    <label for="date_returned">Data consegna</label>
+    <input type="date" id="date_returned" name="date_returned">
+
+    <button type="submit">Salva</button>
+</form>
+{% endblock %}

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}Nuovo ticket{% endblock %}
+{% block content %}
+<h2>Crea ticket</h2>
+<form method="post">
+    <label for="customer_id">Cliente *</label>
+    <select id="customer_id" name="customer_id" required>
+        <option value="">-- seleziona --</option>
+        {% for customer in customers %}
+        <option value="{{ customer['id'] }}">{{ customer['name'] }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="subject">Oggetto *</label>
+    <input type="text" id="subject" name="subject" required>
+
+    <label for="description">Descrizione</label>
+    <textarea id="description" name="description" rows="4"></textarea>
+
+    <button type="submit">Salva</button>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Gestionale Ticket{% endblock %}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+        header { background: #2d6cdf; color: white; padding: 1rem; }
+        nav a { color: white; margin-right: 1rem; text-decoration: none; }
+        main { padding: 1.5rem; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+        th { background: #e8eefc; }
+        .flash { padding: 0.75rem; margin-bottom: 1rem; border-radius: 4px; }
+        .flash.success { background: #d4edda; color: #155724; }
+        .flash.error { background: #f8d7da; color: #721c24; }
+        form label { display: block; margin-top: 0.75rem; }
+        form input, form textarea, form select { width: 100%; padding: 0.5rem; margin-top: 0.25rem; }
+        form button { margin-top: 1rem; padding: 0.75rem 1.5rem; background: #2d6cdf; color: white; border: none; cursor: pointer; }
+        form button:hover { background: #1f4da8; }
+        a.button { display: inline-block; padding: 0.5rem 1rem; background: #2d6cdf; color: white; text-decoration: none; border-radius: 4px; }
+        a.button:hover { background: #1f4da8; }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Gestionale Ticket</h1>
+    <nav>
+        <a href="{{ url_for('index') }}">Dashboard</a>
+        <a href="{{ url_for('customers') }}">Clienti</a>
+        <a href="{{ url_for('tickets') }}">Ticket</a>
+        <a href="{{ url_for('repairs') }}">Riparazioni</a>
+    </nav>
+</header>
+<main>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="flash {{ category }}">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</main>
+</body>
+</html>

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}Clienti{% endblock %}
+{% block content %}
+<h2>Clienti</h2>
+<p><a class="button" href="{{ url_for('add_customer') }}">Nuovo cliente</a></p>
+{% if customers %}
+<table>
+    <thead>
+    <tr>
+        <th>Nome</th>
+        <th>Email</th>
+        <th>Telefono</th>
+        <th>Indirizzo</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for customer in customers %}
+    <tr>
+        <td>{{ customer['name'] }}</td>
+        <td>{{ customer['email'] or '-' }}</td>
+        <td>{{ customer['phone'] or '-' }}</td>
+        <td>{{ customer['address'] or '-' }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>Nessun cliente registrato.</p>
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h2>Riepilogo</h2>
+<ul>
+    <li>Ticket totali: <strong>{{ ticket_count }}</strong></li>
+    <li>Clienti registrati: <strong>{{ customer_count }}</strong></li>
+    <li>Riparazioni totali: <strong>{{ repair_count }}</strong></li>
+</ul>
+<p>
+    <a class="button" href="{{ url_for('customers') }}">Gestisci clienti</a>
+    <a class="button" href="{{ url_for('tickets') }}">Gestisci ticket</a>
+    <a class="button" href="{{ url_for('repairs') }}">Gestisci riparazioni</a>
+</p>
+{% endblock %}

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block title %}Riparazioni{% endblock %}
+{% block content %}
+<h2>Riparazioni</h2>
+<p><a class="button" href="{{ url_for('add_repair') }}">Nuova riparazione</a></p>
+{% if repairs %}
+<table>
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Ticket</th>
+        <th>Cliente</th>
+        <th>Prodotto</th>
+        <th>Descrizione problema</th>
+        <th>Stato</th>
+        <th>Ricevuto</th>
+        <th>Riparato</th>
+        <th>Consegnato</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for repair in repairs %}
+    <tr>
+        <td>{{ repair['id'] }}</td>
+        <td><a href="{{ url_for('ticket_detail', ticket_id=repair['ticket_id']) }}">{{ repair['ticket_subject'] }}</a></td>
+        <td>{{ repair['customer_name'] }}</td>
+        <td>{{ repair['product'] or '-' }}</td>
+        <td>{{ repair['issue_description'] or '-' }}</td>
+        <td>{{ repair['repair_status'] }}</td>
+        <td>{{ repair['date_received'] or '-' }}</td>
+        <td>{{ repair['date_repaired'] or '-' }}</td>
+        <td>{{ repair['date_returned'] or '-' }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>Nessuna riparazione registrata.</p>
+{% endif %}
+{% endblock %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+{% block title %}Ticket #{{ ticket['id'] }}{% endblock %}
+{% block content %}
+<h2>Ticket #{{ ticket['id'] }}</h2>
+<ul>
+    <li><strong>Cliente:</strong> {{ ticket['customer_name'] }}</li>
+    <li><strong>Oggetto:</strong> {{ ticket['subject'] }}</li>
+    <li><strong>Descrizione:</strong> {{ ticket['description'] or 'N/A' }}</li>
+    <li><strong>Stato:</strong> {{ ticket['status'] }}</li>
+    <li><strong>Creato il:</strong> {{ ticket['created_at'] }}</li>
+    <li><strong>Aggiornato il:</strong> {{ ticket['updated_at'] }}</li>
+</ul>
+<form method="post">
+    <label for="status">Aggiorna stato</label>
+    <select id="status" name="status">
+        <option value="open" {% if ticket['status'] == 'open' %}selected{% endif %}>Aperto</option>
+        <option value="in_progress" {% if ticket['status'] == 'in_progress' %}selected{% endif %}>In lavorazione</option>
+        <option value="closed" {% if ticket['status'] == 'closed' %}selected{% endif %}>Chiuso</option>
+    </select>
+    <button type="submit">Aggiorna</button>
+</form>
+<h3>Riparazioni</h3>
+<p><a class="button" href="{{ url_for('add_repair', ticket_id=ticket['id']) }}">Aggiungi riparazione</a></p>
+{% if repairs %}
+<table>
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Prodotto</th>
+        <th>Descrizione problema</th>
+        <th>Stato riparazione</th>
+        <th>Ricevuto</th>
+        <th>Riparato</th>
+        <th>Consegnato</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for repair in repairs %}
+    <tr>
+        <td>{{ repair['id'] }}</td>
+        <td>{{ repair['product'] or 'N/A' }}</td>
+        <td>{{ repair['issue_description'] or 'N/A' }}</td>
+        <td>{{ repair['repair_status'] }}</td>
+        <td>{{ repair['date_received'] or '-' }}</td>
+        <td>{{ repair['date_repaired'] or '-' }}</td>
+        <td>{{ repair['date_returned'] or '-' }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>Nessuna riparazione associata.</p>
+{% endif %}
+{% endblock %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block title %}Ticket{% endblock %}
+{% block content %}
+<h2>Ticket</h2>
+<p><a class="button" href="{{ url_for('add_ticket') }}">Nuovo ticket</a></p>
+{% if tickets %}
+<table>
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Cliente</th>
+        <th>Oggetto</th>
+        <th>Stato</th>
+        <th>Creato il</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for ticket in tickets %}
+    <tr>
+        <td><a href="{{ url_for('ticket_detail', ticket_id=ticket['id']) }}">{{ ticket['id'] }}</a></td>
+        <td>{{ ticket['customer_name'] }}</td>
+        <td>{{ ticket['subject'] }}</td>
+        <td>{{ ticket['status'] }}</td>
+        <td>{{ ticket['created_at'] }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>Nessun ticket presente.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a shared base layout and individual Jinja templates for the dashboard, customers, tickets, and repairs pages
- configure the Flask factory to set the secret key, initialize the database on startup, and expose an application instance for the CLI

## Testing
- flask --app app.py run

------
https://chatgpt.com/codex/tasks/task_e_68de2b96f5fc832d8001a0840ecd73e2