### PR TITLE
Add ticket status filtering to ticket list

### DIFF
--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -2,7 +2,17 @@
 {% block title %}Ticket{% endblock %}
 {% block content %}
 <h2>Ticket</h2>
-<p><a class="button" href="{{ url_for('add_ticket') }}">Nuovo ticket</a></p>
+<form method="get" action="{{ url_for('tickets') }}" class="filters">
+    <label for="status">Stato:</label>
+    <select name="status" id="status" onchange="this.form.submit()">
+        <option value="" {% if not selected_status %}selected{% endif %}>Tutti</option>
+        {% for status in statuses %}
+        <option value="{{ status }}" {% if status == selected_status %}selected{% endif %}>{{ status }}</option>
+        {% endfor %}
+    </select>
+    <noscript><button type="submit">Filtra</button></noscript>
+</form>
+<p><a class="button" href="{{ url_for('add_ticket', **current_filters) }}">Nuovo ticket</a></p>
 {% if tickets %}
 <table>
     <thead>


### PR DESCRIPTION
## Summary
- read the requested ticket status from the query string and apply a matching filter when fetching tickets
- expose the available status list and current filter to the template
- add a GET form with a status select, including a reset option, and preserve filters on the "Nuovo ticket" link

## Testing
- python -m compileall app.py templates/tickets.html

------
https://chatgpt.com/codex/tasks/task_e_68de3fa2d220832db9a57e42f77df71b