### PR TITLE
Uniforma la formattazione degli identificativi ticket

### DIFF
--- a/templates/add_repair.html
+++ b/templates/add_repair.html
@@ -8,7 +8,7 @@
         <option value="">-- seleziona --</option>
         {% for ticket in tickets %}
         {% set selected = request.args.get('ticket_id') == ticket['id']|string %}
-        <option value="{{ ticket['id'] }}" {% if selected %}selected{% endif %}>{{ ticket['subject'] }}</option>
+        <option value="{{ ticket['id'] }}" {% if selected %}selected{% endif %}>{{ '%04d'|format(ticket['id']) }} - {{ ticket['subject'] }}</option>
         {% endfor %}
     </select>
 

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -22,7 +22,7 @@
     {% for repair in repairs %}
     <tr>
         <td>{{ repair['id'] }}</td>
-        <td><a href="{{ url_for('ticket_detail', ticket_id=repair['ticket_id']) }}">{{ repair['ticket_subject'] }}</a></td>
+        <td><a href="{{ url_for('ticket_detail', ticket_id=repair['ticket_id']) }}">{{ '%04d'|format(repair['ticket_id']) }} - {{ repair['ticket_subject'] }}</a></td>
         <td>{{ repair['customer_name'] }}</td>
         <td>{{ repair['product'] or '-' }}</td>
         <td>{{ repair['issue_description'] or '-' }}</td>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,12 +1,17 @@
 {% extends 'base.html' %}
-{% block title %}Ticket #{{ ticket['id'] }}{% endblock %}
+{% set ticket_number = '%04d'|format(ticket['id']) %}
+{% block title %}Ticket #{{ ticket_number }}{% endblock %}
 {% block content %}
-<h2>Ticket #{{ ticket['id'] }}</h2>
+<div class="ticket-header">
+    <h2>Ticket #{{ ticket_number }}</h2>
+    <div class="ticket-header-details">
+        <div><strong>Cliente:</strong> {{ ticket['customer_name'] }}</div>
+        <div><strong>Stato:</strong> {{ ticket['status'] }}</div>
+    </div>
+</div>
 <ul>
-    <li><strong>Cliente:</strong> {{ ticket['customer_name'] }}</li>
     <li><strong>Oggetto:</strong> {{ ticket['subject'] }}</li>
     <li><strong>Descrizione:</strong> {{ ticket['description'] or 'N/A' }}</li>
-    <li><strong>Stato:</strong> {{ ticket['status'] }}</li>
     <li><strong>Creato il:</strong> {{ ticket['created_at'] }}</li>
     <li><strong>Aggiornato il:</strong> {{ ticket['updated_at'] }}</li>
 </ul>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -8,19 +8,20 @@
     <thead>
     <tr>
         <th>ID</th>
-        <th>Cliente</th>
+        <th>Cliente / Stato</th>
         <th>Oggetto</th>
-        <th>Stato</th>
         <th>Creato il</th>
     </tr>
     </thead>
     <tbody>
     {% for ticket in tickets %}
     <tr>
-        <td><a href="{{ url_for('ticket_detail', ticket_id=ticket['id']) }}">{{ ticket['id'] }}</a></td>
-        <td>{{ ticket['customer_name'] }}</td>
+        <td><a href="{{ url_for('ticket_detail', ticket_id=ticket['id']) }}">{{ '%04d'|format(ticket['id']) }}</a></td>
+        <td>
+            <div class="ticket-customer">{{ ticket['customer_name'] }}</div>
+            <div class="ticket-status">{{ ticket['status'] }}</div>
+        </td>
         <td>{{ ticket['subject'] }}</td>
-        <td>{{ ticket['status'] }}</td>
         <td>{{ ticket['created_at'] }}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- applica una formattazione a quattro cifre agli identificativi dei ticket nell'elenco, nel dettaglio e nelle viste delle riparazioni
- aggiorna il layout della tabella dei ticket affiancando cliente e stato in un'unica colonna
- mostra il numero formattato anche nella selezione per l'aggiunta di nuove riparazioni per mantenere la coerenza visiva

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de3f9488dc832db6d4e9db06c954e3