### PR TITLE
Aggiorna workflow stati ticket

### DIFF
--- a/migrations/20240217_ticket_status_update.sql
+++ b/migrations/20240217_ticket_status_update.sql
@@ -1,0 +1,19 @@
+-- Migrazione per aggiornare gli stati dei ticket ai nuovi valori introdotti
+-- nel 2024-02-17.  Eseguire questo script dopo aver aggiornato l'applicazione
+-- per convertire i valori legacy ed evitare dati inconsistenti.
+
+BEGIN TRANSACTION;
+
+UPDATE tickets SET status = 'accettazione'
+WHERE status IN ('open', 'aperto');
+
+UPDATE tickets SET status = 'preventivo'
+WHERE status IN ('in_progress', 'processing', 'preventivo');
+
+UPDATE tickets SET status = 'riparato'
+WHERE status IN ('repaired', 'riparato');
+
+UPDATE tickets SET status = 'chiuso'
+WHERE status IN ('closed', 'chiuso');
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS tickets (
     customer_id INTEGER NOT NULL,
     subject TEXT NOT NULL,
     description TEXT,
-    status TEXT NOT NULL DEFAULT 'open',
+    status TEXT NOT NULL DEFAULT 'accettazione'
+        CHECK (status IN ('accettazione', 'preventivo', 'riparato', 'chiuso')),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -6,16 +6,16 @@
     <li><strong>Cliente:</strong> {{ ticket['customer_name'] }}</li>
     <li><strong>Oggetto:</strong> {{ ticket['subject'] }}</li>
     <li><strong>Descrizione:</strong> {{ ticket['description'] or 'N/A' }}</li>
-    <li><strong>Stato:</strong> {{ ticket['status'] }}</li>
+    <li><strong>Stato:</strong> {{ status_labels.get(ticket['status'], ticket['status']) }}</li>
     <li><strong>Creato il:</strong> {{ ticket['created_at'] }}</li>
     <li><strong>Aggiornato il:</strong> {{ ticket['updated_at'] }}</li>
 </ul>
 <form method="post">
     <label for="status">Aggiorna stato</label>
     <select id="status" name="status">
-        <option value="open" {% if ticket['status'] == 'open' %}selected{% endif %}>Aperto</option>
-        <option value="in_progress" {% if ticket['status'] == 'in_progress' %}selected{% endif %}>In lavorazione</option>
-        <option value="closed" {% if ticket['status'] == 'closed' %}selected{% endif %}>Chiuso</option>
+        {% for value, label in status_choices %}
+        <option value="{{ value }}" {% if ticket['status'] == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
     </select>
     <button type="submit">Aggiorna</button>
 </form>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -20,7 +20,7 @@
         <td><a href="{{ url_for('ticket_detail', ticket_id=ticket['id']) }}">{{ ticket['id'] }}</a></td>
         <td>{{ ticket['customer_name'] }}</td>
         <td>{{ ticket['subject'] }}</td>
-        <td>{{ ticket['status'] }}</td>
+        <td>{{ status_labels.get(ticket['status'], ticket['status']) }}</td>
         <td>{{ ticket['created_at'] }}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- imposta il valore predefinito dei ticket su "accettazione" con vincolo CHECK nello schema
- centralizza le etichette degli stati in app.py e aggiorna la validazione e le viste per i nuovi valori
- aggiunge una migrazione SQL per convertire gli stati legacy nei nuovi nomi localizzati

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68de3f9cc238832d9ddc8a3a19e61767