### PR TITLE
Add custom error handlers with dedicated templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,6 +195,15 @@ def create_app() -> Flask:
         tickets = db.execute('SELECT id, subject FROM tickets ORDER BY created_at DESC').fetchall()
         return render_template('add_repair.html', tickets=tickets)
 
+    # Gestione errori HTTP comuni con template dedicati.
+    @app.errorhandler(404)
+    def not_found(error):
+        return render_template('errors/404.html'), 404
+
+    @app.errorhandler(500)
+    def internal_server_error(error):
+        return render_template('errors/500.html'), 500
+
     return app
 
 

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block title %}Pagina non trovata - Gestionale Ticket{% endblock %}
+
+{% block content %}
+<h2>Ops! Pagina non trovata.</h2>
+<p>La risorsa che stavi cercando potrebbe essere stata rimossa, rinominata o non è mai esistita.</p>
+<p>
+    <a class="button" href="{{ url_for('index') }}">Torna alla dashboard</a>
+    <a class="button" href="{{ url_for('tickets') }}">Vai ai ticket</a>
+</p>
+{% endblock %}

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block title %}Errore interno - Gestionale Ticket{% endblock %}
+
+{% block content %}
+<h2>Ci scusiamo, qualcosa è andato storto.</h2>
+<p>Si è verificato un problema interno. Il nostro team è stato informato e sta lavorando per risolverlo.</p>
+<p>
+    <a class="button" href="{{ url_for('index') }}">Torna alla dashboard</a>
+    <a class="button" href="{{ url_for('tickets') }}">Vai ai ticket</a>
+</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add HTTP error handlers to the Flask application factory so 404 and 500 codes render dedicated templates
- create user-friendly templates for the most common errors with quick navigation links

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7716b508832dbb084fb5652c209d