### PR TITLE
Enforce required fields for repair creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Questo progetto è un semplice gestionale a ticket pensato per officine o centri
 - `static/style.css` – foglio di stile di base per la grafica dell’interfaccia.
 - `requirements.txt` – elenco dei pacchetti Python necessari.
 
+## Test manuali consigliati
+
+Per verificare la corretta gestione dei campi obbligatori nella creazione di una riparazione:
+
+1. Avvia l’applicazione con `flask --app app.py run --reload`.
+2. Visita la pagina **Nuova riparazione** (`/repairs/new`) e prova a inviare il modulo senza compilare *Prodotto* o *Descrizione problema*; il browser blocca l’invio e mostra un messaggio di validazione HTML5.
+3. (Opzionale) Rimuovi temporaneamente gli attributi `required` dal modulo tramite gli strumenti di sviluppo del browser e ripeti l’invio con campi vuoti: l’applicazione visualizza messaggi di errore e non registra la riparazione.
+
 ## Espansioni possibili
 
 Questo gestionale è pensato come base da cui partire.  Alcune idee per evolverlo:

--- a/app.py
+++ b/app.py
@@ -178,14 +178,24 @@ def create_app() -> Flask:
             date_received = request.form.get('date_received') or None
             date_repaired = request.form.get('date_repaired') or None
             date_returned = request.form.get('date_returned') or None
+
+            errors = []
             if not ticket_id:
-                flash('È necessario selezionare un ticket.', 'error')
+                errors.append('È necessario selezionare un ticket.')
+            if not product:
+                errors.append('Il prodotto è obbligatorio.')
+            if not issue_description:
+                errors.append('La descrizione del problema è obbligatoria.')
+
+            if errors:
+                for message in errors:
+                    flash(message, 'error')
             else:
                 db.execute(
                     'INSERT INTO repairs '
                     '(ticket_id, product, issue_description, repair_status, date_received, date_repaired, date_returned) '
                     'VALUES (?, ?, ?, ?, ?, ?, ?)',
-                    (ticket_id, product or None, issue_description or None, repair_status,
+                    (ticket_id, product, issue_description, repair_status,
                      date_received, date_repaired, date_returned)
                 )
                 db.commit()

--- a/templates/add_repair.html
+++ b/templates/add_repair.html
@@ -12,11 +12,11 @@
         {% endfor %}
     </select>
 
-    <label for="product">Prodotto</label>
-    <input type="text" id="product" name="product">
+    <label for="product">Prodotto *</label>
+    <input type="text" id="product" name="product" required minlength="2">
 
-    <label for="issue_description">Descrizione problema</label>
-    <textarea id="issue_description" name="issue_description" rows="4"></textarea>
+    <label for="issue_description">Descrizione problema *</label>
+    <textarea id="issue_description" name="issue_description" rows="4" required minlength="5"></textarea>
 
     <label for="repair_status">Stato riparazione</label>
     <select id="repair_status" name="repair_status">


### PR DESCRIPTION
## Summary
- validate required product and issue description fields when creating a repair
- mark the repair form inputs as required to provide client-side feedback
- document manual validation steps for the repair workflow

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de7717f9f0832db07405d1803ae2fe