### PR TITLE
Add status badges and legend to ticket and repair templates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,46 @@
         form button:hover { background: #1f4da8; }
         a.button { display: inline-block; padding: 0.5rem 1rem; background: #2d6cdf; color: white; text-decoration: none; border-radius: 4px; }
         a.button:hover { background: #1f4da8; }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.15rem 0.5rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
+        }
+        .badge-open,
+        .badge-accettazione {
+            background: #e3f2fd;
+            color: #0d47a1;
+        }
+        .badge-in-progress,
+        .badge-preventivo {
+            background: #fff3cd;
+            color: #8a6d3b;
+        }
+        .badge-pending {
+            background: #ede7f6;
+            color: #4527a0;
+        }
+        .badge-completed,
+        .badge-riparato {
+            background: #e8f5e9;
+            color: #1b5e20;
+        }
+        .badge-closed,
+        .badge-chiuso {
+            background: #eceff1;
+            color: #37474f;
+        }
+        .status-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem 1rem;
+            margin: 1rem 0;
+        }
     </style>
 </head>
 <body>

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -1,7 +1,17 @@
 {% extends 'base.html' %}
 {% block title %}Riparazioni{% endblock %}
 {% block content %}
+{% set repair_status_labels = {
+    'pending': 'In attesa',
+    'in_progress': 'In lavorazione',
+    'completed': 'Completata'
+} %}
 <h2>Riparazioni</h2>
+<div class="status-legend">
+    <span class="badge badge-pending">In attesa</span>
+    <span class="badge badge-in-progress">In lavorazione</span>
+    <span class="badge badge-completed">Completata</span>
+</div>
 <p><a class="button" href="{{ url_for('add_repair') }}">Nuova riparazione</a></p>
 {% if repairs %}
 <table>
@@ -26,7 +36,10 @@
         <td>{{ repair['customer_name'] }}</td>
         <td>{{ repair['product'] or '-' }}</td>
         <td>{{ repair['issue_description'] or '-' }}</td>
-        <td>{{ repair['repair_status'] }}</td>
+        {% set repair_status_slug = repair['repair_status']|lower|replace(' ', '-')|replace('_', '-') %}
+        <td>
+            <span class="badge badge-{{ repair_status_slug }}">{{ repair_status_labels.get(repair['repair_status'], repair['repair_status']) }}</span>
+        </td>
         <td>{{ repair['date_received'] or '-' }}</td>
         <td>{{ repair['date_repaired'] or '-' }}</td>
         <td>{{ repair['date_returned'] or '-' }}</td>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -2,11 +2,29 @@
 {% set ticket_number = '%04d'|format(ticket['id']) %}
 {% block title %}Ticket #{{ ticket_number }}{% endblock %}
 {% block content %}
+{% set ticket_status_labels = {
+    'open': 'Aperto',
+    'in_progress': 'In lavorazione',
+    'closed': 'Chiuso',
+    'Accettazione': 'Accettazione',
+    'Preventivo': 'Preventivo',
+    'Riparato': 'Riparato',
+    'Chiuso': 'Chiuso'
+} %}
+{% set repair_status_labels = {
+    'pending': 'In attesa',
+    'in_progress': 'In lavorazione',
+    'completed': 'Completata'
+} %}
 <div class="ticket-header">
     <h2>Ticket #{{ ticket_number }}</h2>
     <div class="ticket-header-details">
         <div><strong>Cliente:</strong> {{ ticket['customer_name'] }}</div>
-        <div><strong>Stato:</strong> {{ ticket['status'] }}</div>
+        <div>
+            <strong>Stato:</strong>
+            {% set status_slug = ticket['status']|lower|replace(' ', '-')|replace('_', '-') %}
+            <span class="badge badge-{{ status_slug }}">{{ ticket_status_labels.get(ticket['status'], ticket['status']) }}</span>
+        </div>
     </div>
 </div>
 <ul>
@@ -45,7 +63,10 @@
         <td>{{ repair['id'] }}</td>
         <td>{{ repair['product'] or 'N/A' }}</td>
         <td>{{ repair['issue_description'] or 'N/A' }}</td>
-        <td>{{ repair['repair_status'] }}</td>
+        {% set repair_status_slug = repair['repair_status']|lower|replace(' ', '-')|replace('_', '-') %}
+        <td>
+            <span class="badge badge-{{ repair_status_slug }}">{{ repair_status_labels.get(repair['repair_status'], repair['repair_status']) }}</span>
+        </td>
         <td>{{ repair['date_received'] or '-' }}</td>
         <td>{{ repair['date_repaired'] or '-' }}</td>
         <td>{{ repair['date_returned'] or '-' }}</td>


### PR DESCRIPTION
## Summary
- add shared badge styles for ticket and repair status indicators
- render ticket and repair statuses with localized badge labels in detail and list pages
- introduce a repairs status legend to make the list of repair records easier to scan

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de77165324832dba20d86b92bb920c