### PR TITLE
Use canonical ticket status slugs with shared labels

### DIFF
--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -2,15 +2,6 @@
 {% set ticket_number = '%04d'|format(ticket['id']) %}
 {% block title %}Ticket #{{ ticket_number }}{% endblock %}
 {% block content %}
-{% set ticket_status_labels = {
-    'open': 'Aperto',
-    'in_progress': 'In lavorazione',
-    'closed': 'Chiuso',
-    'Accettazione': 'Accettazione',
-    'Preventivo': 'Preventivo',
-    'Riparato': 'Riparato',
-    'Chiuso': 'Chiuso'
-} %}
 {% set repair_status_labels = {
     'pending': 'In attesa',
     'in_progress': 'In lavorazione',
@@ -22,7 +13,7 @@
         <div><strong>Cliente:</strong> {{ ticket['customer_name'] }}</div>
         <div>
             <strong>Stato:</strong>
-            {% set status_slug = ticket['status']|lower|replace(' ', '-')|replace('_', '-') %}
+            {% set status_slug = ticket['status']|replace('_', '-') %}
             <span class="badge badge-{{ status_slug }}">{{ ticket_status_labels.get(ticket['status'], ticket['status']) }}</span>
         </div>
     </div>
@@ -36,9 +27,9 @@
 <form method="post">
     <label for="status">Aggiorna stato</label>
     <select id="status" name="status">
-        <option value="open" {% if ticket['status'] == 'open' %}selected{% endif %}>Aperto</option>
-        <option value="in_progress" {% if ticket['status'] == 'in_progress' %}selected{% endif %}>In lavorazione</option>
-        <option value="closed" {% if ticket['status'] == 'closed' %}selected{% endif %}>Chiuso</option>
+        {% for value, label in ticket_statuses %}
+        <option value="{{ value }}" {% if ticket['status'] == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
     </select>
     <button type="submit">Aggiorna</button>
 </form>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -6,8 +6,8 @@
     <label for="status">Stato:</label>
     <select name="status" id="status" onchange="this.form.submit()">
         <option value="" {% if not selected_status %}selected{% endif %}>Tutti</option>
-        {% for status in statuses %}
-        <option value="{{ status }}" {% if status == selected_status %}selected{% endif %}>{{ status }}</option>
+        {% for value, label in statuses %}
+        <option value="{{ value }}" {% if value == selected_status %}selected{% endif %}>{{ label }}</option>
         {% endfor %}
     </select>
     <noscript><button type="submit">Filtra</button></noscript>
@@ -29,7 +29,10 @@
         <td><a href="{{ url_for('ticket_detail', ticket_id=ticket['id']) }}">{{ '%04d'|format(ticket['id']) }}</a></td>
         <td>
             <div class="ticket-customer">{{ ticket['customer_name'] }}</div>
-            <div class="ticket-status">{{ ticket['status'] }}</div>
+            {% set status_slug = ticket['status']|replace('_', '-') %}
+            <div class="ticket-status">
+                <span class="badge badge-{{ status_slug }}">{{ ticket_status_labels.get(ticket['status'], ticket['status']) }}</span>
+            </div>
         </td>
         <td>{{ ticket['subject'] }}</td>
         <td>{{ ticket['created_at'] }}</td>


### PR DESCRIPTION
## Summary
- replace the hard-coded Italian status strings with canonical slug/label pairs shared across the app
- validate ticket list filters against the known slugs and surface the labels in both the list and detail templates
- reuse the shared mapping for ticket badges and selectors so statuses stay translated while using consistent values

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68de9eade4a4832d8960a3e7c0294cdd