### PR TITLE
Integrate repair fields directly into tickets

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -25,21 +25,13 @@ CREATE TABLE IF NOT EXISTS tickets (
     subject TEXT NOT NULL,
     description TEXT,
     status TEXT NOT NULL DEFAULT 'open',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE
-);
-
--- Tabella riparazioni.  Una riparazione fa riferimento a un ticket e
--- memorizza informazioni dettagliate sull'intervento e il suo stato.
-CREATE TABLE IF NOT EXISTS repairs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    ticket_id INTEGER NOT NULL,
     product TEXT,
     issue_description TEXT,
     repair_status TEXT NOT NULL DEFAULT 'pending',
     date_received DATE,
     date_repaired DATE,
     date_returned DATE,
-    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE
 );

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -17,6 +17,31 @@
     <label for="description">Descrizione</label>
     <textarea id="description" name="description" rows="4"></textarea>
 
+    <h3>Dati riparazione</h3>
+    <p class="info">Compila le informazioni se già disponibili; potrai aggiornarle successivamente dal dettaglio ticket.</p>
+
+    <label for="product">Prodotto</label>
+    <input type="text" id="product" name="product" value="{{ request.form.get('product', '') }}">
+
+    <label for="issue_description">Descrizione problema</label>
+    <textarea id="issue_description" name="issue_description" rows="4">{{ request.form.get('issue_description', '') }}</textarea>
+
+    <label for="repair_status">Stato riparazione</label>
+    <select id="repair_status" name="repair_status">
+        {% for value, label in repair_statuses %}
+        <option value="{{ value }}" {% if request.form.get('repair_status', repair_statuses[0][0]) == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="date_received">Data ricezione</label>
+    <input type="date" id="date_received" name="date_received" value="{{ request.form.get('date_received', '') }}">
+
+    <label for="date_repaired">Data riparazione</label>
+    <input type="date" id="date_repaired" name="date_repaired" value="{{ request.form.get('date_repaired', '') }}">
+
+    <label for="date_returned">Data consegna</label>
+    <input type="date" id="date_returned" name="date_returned" value="{{ request.form.get('date_returned', '') }}">
+
     <button type="submit">Salva</button>
 </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,7 +77,7 @@
         <a href="{{ url_for('index') }}">Dashboard</a>
         <a href="{{ url_for('customers') }}">Clienti</a>
         <a href="{{ url_for('tickets') }}">Ticket</a>
-        <a href="{{ url_for('repairs') }}">Riparazioni</a>
+        <a href="{{ url_for('repairs') }}">Storico riparazioni</a>
     </nav>
     <div class="auth-links">
         {% if current_user.is_authenticated %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,11 +5,11 @@
 <ul>
     <li>Ticket totali: <strong>{{ ticket_count }}</strong></li>
     <li>Clienti registrati: <strong>{{ customer_count }}</strong></li>
-    <li>Riparazioni totali: <strong>{{ repair_count }}</strong></li>
+    <li>Ticket con dati di riparazione: <strong>{{ repair_count }}</strong></li>
 </ul>
 <p>
     <a class="button" href="{{ url_for('customers') }}">Gestisci clienti</a>
     <a class="button" href="{{ url_for('tickets') }}">Gestisci ticket</a>
-    <a class="button" href="{{ url_for('repairs') }}">Gestisci riparazioni</a>
+    <a class="button" href="{{ url_for('repairs') }}">Storico riparazioni</a>
 </p>
 {% endblock %}

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -1,23 +1,17 @@
 {% extends 'base.html' %}
 {% block title %}Riparazioni{% endblock %}
 {% block content %}
-{% set repair_status_labels = {
-    'pending': 'In attesa',
-    'in_progress': 'In lavorazione',
-    'completed': 'Completata'
-} %}
+{% set repair_status_labels = repair_status_labels or {} %}
 <h2>Riparazioni</h2>
 <div class="status-legend">
     <span class="badge badge-pending">In attesa</span>
     <span class="badge badge-in-progress">In lavorazione</span>
     <span class="badge badge-completed">Completata</span>
 </div>
-<p><a class="button" href="{{ url_for('add_repair') }}">Nuova riparazione</a></p>
 {% if repairs %}
 <table>
     <thead>
     <tr>
-        <th>ID</th>
         <th>Ticket</th>
         <th>Cliente</th>
         <th>Prodotto</th>
@@ -31,14 +25,14 @@
     <tbody>
     {% for repair in repairs %}
     <tr>
-        <td>{{ repair['id'] }}</td>
-        <td><a href="{{ url_for('ticket_detail', ticket_id=repair['ticket_id']) }}">{{ '%04d'|format(repair['ticket_id']) }} - {{ repair['ticket_subject'] }}</a></td>
+        <td><a href="{{ url_for('ticket_detail', ticket_id=repair['id']) }}">{{ '%04d'|format(repair['id']) }} - {{ repair['subject'] }}</a></td>
         <td>{{ repair['customer_name'] }}</td>
         <td>{{ repair['product'] or '-' }}</td>
         <td>{{ repair['issue_description'] or '-' }}</td>
-        {% set repair_status_slug = repair['repair_status']|lower|replace(' ', '-')|replace('_', '-') %}
+        {% set repair_status_slug = (repair['repair_status'] or '')|lower|replace(' ', '-')|replace('_', '-') %}
         <td>
-            <span class="badge badge-{{ repair_status_slug }}">{{ repair_status_labels.get(repair['repair_status'], repair['repair_status']) }}</span>
+            {% set status_label = repair_status_labels.get(repair['repair_status'], repair['repair_status'] or 'N/A') %}
+            <span class="badge badge-{{ repair_status_slug if repair_status_slug else 'pending' }}">{{ status_label }}</span>
         </td>
         <td>{{ repair['date_received'] or '-' }}</td>
         <td>{{ repair['date_repaired'] or '-' }}</td>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -2,11 +2,7 @@
 {% set ticket_number = '%04d'|format(ticket['id']) %}
 {% block title %}Ticket #{{ ticket_number }}{% endblock %}
 {% block content %}
-{% set repair_status_labels = {
-    'pending': 'In attesa',
-    'in_progress': 'In lavorazione',
-    'completed': 'Completata'
-} %}
+{% set can_edit = current_user.is_authenticated and current_user.is_admin %}
 <div class="ticket-header">
     <h2>Ticket #{{ ticket_number }}</h2>
     <div class="ticket-header-details">
@@ -24,48 +20,41 @@
     <li><strong>Creato il:</strong> {{ ticket['created_at'] }}</li>
     <li><strong>Aggiornato il:</strong> {{ ticket['updated_at'] }}</li>
 </ul>
-<form method="post">
-    <label for="status">Aggiorna stato</label>
-    <select id="status" name="status">
+<form method="post" class="ticket-edit-form">
+    <label for="status">Stato ticket</label>
+    <select id="status" name="status" {% if not can_edit %}disabled{% endif %}>
         {% for value, label in ticket_statuses %}
         <option value="{{ value }}" {% if ticket['status'] == value %}selected{% endif %}>{{ label }}</option>
         {% endfor %}
     </select>
-    <button type="submit">Aggiorna</button>
+
+    <h3>Dati riparazione</h3>
+    <label for="product">Prodotto</label>
+    <input type="text" id="product" name="product" value="{{ ticket['product'] or '' }}" {% if not can_edit %}readonly{% endif %}>
+
+    <label for="issue_description">Descrizione problema</label>
+    <textarea id="issue_description" name="issue_description" rows="4" {% if not can_edit %}readonly{% endif %}>{{ ticket['issue_description'] or '' }}</textarea>
+
+    <label for="repair_status">Stato riparazione</label>
+    <select id="repair_status" name="repair_status" {% if not can_edit %}disabled{% endif %}>
+        {% for value, label in repair_statuses %}
+        <option value="{{ value }}" {% if ticket['repair_status'] == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="date_received">Data ricezione</label>
+    <input type="date" id="date_received" name="date_received" value="{{ ticket['date_received'] or '' }}" {% if not can_edit %}readonly{% endif %}>
+
+    <label for="date_repaired">Data riparazione</label>
+    <input type="date" id="date_repaired" name="date_repaired" value="{{ ticket['date_repaired'] or '' }}" {% if not can_edit %}readonly{% endif %}>
+
+    <label for="date_returned">Data consegna</label>
+    <input type="date" id="date_returned" name="date_returned" value="{{ ticket['date_returned'] or '' }}" {% if not can_edit %}readonly{% endif %}>
+
+    {% if can_edit %}
+    <button type="submit">Salva modifiche</button>
+    {% else %}
+    <p class="info">Solo un amministratore può modificare lo stato del ticket e i dati di riparazione.</p>
+    {% endif %}
 </form>
-<h3>Riparazioni</h3>
-<p><a class="button" href="{{ url_for('add_repair', ticket_id=ticket['id']) }}">Aggiungi riparazione</a></p>
-{% if repairs %}
-<table>
-    <thead>
-    <tr>
-        <th>ID</th>
-        <th>Prodotto</th>
-        <th>Descrizione problema</th>
-        <th>Stato riparazione</th>
-        <th>Ricevuto</th>
-        <th>Riparato</th>
-        <th>Consegnato</th>
-    </tr>
-    </thead>
-    <tbody>
-    {% for repair in repairs %}
-    <tr>
-        <td>{{ repair['id'] }}</td>
-        <td>{{ repair['product'] or 'N/A' }}</td>
-        <td>{{ repair['issue_description'] or 'N/A' }}</td>
-        {% set repair_status_slug = repair['repair_status']|lower|replace(' ', '-')|replace('_', '-') %}
-        <td>
-            <span class="badge badge-{{ repair_status_slug }}">{{ repair_status_labels.get(repair['repair_status'], repair['repair_status']) }}</span>
-        </td>
-        <td>{{ repair['date_received'] or '-' }}</td>
-        <td>{{ repair['date_repaired'] or '-' }}</td>
-        <td>{{ repair['date_returned'] or '-' }}</td>
-    </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% else %}
-<p>Nessuna riparazione associata.</p>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- move repair columns into the tickets table so repair data lives on each ticket record
- update Flask routes to collect, persist, and display the embedded repair information
- refresh the ticket and repair templates to edit and review repair details without the separate repair form

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dea3c4aa70832d91aa416e5ea50f8e