### PR TITLE
Allow registering an admin when none exist

### DIFF
--- a/templates/register.html
+++ b/templates/register.html
@@ -15,8 +15,8 @@
         <option value="user">Utente</option>
         <option value="admin">Amministratore</option>
     </select>
-    {% elif not has_users %}
-    <p class="info">Il primo account creato sarà amministratore.</p>
+    {% elif not admin_exists %}
+    <p class="info">Non esiste ancora alcun amministratore: questo account sarà creato come amministratore.</p>
     {% endif %}
 
     <button type="submit">Registrati</button>


### PR DESCRIPTION
## Summary
- update the registration logic to check for existing admins instead of total users
- force creation of an admin account when no admins exist while keeping admin-only restrictions otherwise
- refresh the registration page messaging to explain when an automatic admin will be created

## Testing
- `python - <<'PY' ... (manual verification script)`

------
https://chatgpt.com/codex/tasks/task_e_68dfcc430640832d999271da26879948