### PR TITLE
Allow open user registration and add admin user dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,6 +76,15 @@ def create_app() -> Flask:
         return render_template('index.html', ticket_count=ticket_count,
                                customer_count=customer_count, repair_count=repair_count)
 
+    @app.route('/admin/users')
+    @admin_required
+    def admin_users():
+        db = get_db()
+        users = db.execute(
+            'SELECT id, username, role, created_at FROM users ORDER BY username'
+        ).fetchall()
+        return render_template('admin_users.html', users=users)
+
     # Lista clienti
     @app.route('/customers')
     @login_required

--- a/auth.py
+++ b/auth.py
@@ -120,16 +120,9 @@ def register():
         ).fetchone()
     )
 
-    if admin_exists and (
-        not current_user.is_authenticated
-        or not getattr(current_user, 'is_admin', False)
-    ):
-        flash('Solo un amministratore può creare nuovi utenti.', 'error')
-        if current_user.is_authenticated:
-            return redirect(url_for('index'))
-        return redirect(url_for('auth.login'))
-
-    allow_role_selection = admin_exists and getattr(current_user, 'is_admin', False)
+    allow_role_selection = (
+        current_user.is_authenticated and getattr(current_user, 'is_admin', False)
+    )
 
     if request.method == 'POST':
         username = request.form.get('username', '').strip()

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}Gestione utenti{% endblock %}
+{% block content %}
+<h2>Utenti registrati</h2>
+<p>Visualizza l'elenco degli account registrati nell'applicazione.</p>
+{% if users %}
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nome utente</th>
+            <th>Ruolo</th>
+            <th>Creato il</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for user in users %}
+        <tr>
+            <td>{{ user.id }}</td>
+            <td>{{ user.username }}</td>
+            <td>{{ user.role }}</td>
+            <td>{{ user.created_at }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p class="info">Non sono ancora presenti utenti registrati.</p>
+{% endif %}
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,6 +78,9 @@
         <a href="{{ url_for('customers') }}">Clienti</a>
         <a href="{{ url_for('tickets') }}">Ticket</a>
         <a href="{{ url_for('repairs') }}">Storico riparazioni</a>
+        {% if current_user.is_authenticated and current_user.role == 'admin' %}
+            <a href="{{ url_for('admin_users') }}">Utenti</a>
+        {% endif %}
     </nav>
     <div class="auth-links">
         {% if current_user.is_authenticated %}


### PR DESCRIPTION
## Summary
- allow any visitor to create an account while still enforcing admin approval for role changes
- let administrators select a role for new accounts and keep the first user as admin when none exist
- add an admin-only user overview page and navigation link to review registered accounts

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68dfcb1c379c832db13410845a958c2c