### PR TITLE
Fix register view syntax regression

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -114,8 +114,6 @@ def logout():
 @bp.route('/register', methods=['GET', 'POST'])
 def register():
     db = get_db()
-    admin_exists = bool(
-        db.execute(
     # verifica se esiste almeno un amministratore
     admin_exists = bool(
         db.execute(
@@ -168,10 +166,6 @@ def register():
             flash('Utente registrato con successo.', 'success')
             return redirect(url_for('auth.login'))
 
-    return render_template(
-        'register.html',
-        allow_role_selection=allow_role_selection,
-        admin_exists=admin_exists,
     return render_template(
         'register.html',
         allow_role_selection=allow_role_selection,


### PR DESCRIPTION
## Summary
- remove duplicated statements in the registration view that introduced a syntax error
- keep a single render_template call with all required context values

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dfdc14d094832dbec50c166fdcec75