### PR TITLE
Add payment information field to tickets

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ TICKET_HISTORY_FIELD_LABELS = {
     'status': 'Stato ticket',
     'product': 'Prodotto',
     'issue_description': 'Descrizione problema',
+    'payment_info': 'Informazioni pagamento',
     'repair_status': 'Stato riparazione',
     'date_received': 'Data ricezione',
     'date_repaired': 'Data riparazione',
@@ -167,6 +168,7 @@ def create_app() -> Flask:
             description = request.form.get('description', '').strip()
             product = request.form.get('product', '').strip()
             issue_description = request.form.get('issue_description', '').strip()
+            payment_info = request.form.get('payment_info', '').strip()
             repair_status = request.form.get('repair_status', DEFAULT_REPAIR_STATUS)
             if repair_status not in REPAIR_STATUS_VALUES:
                 repair_status = DEFAULT_REPAIR_STATUS
@@ -178,9 +180,9 @@ def create_app() -> Flask:
             else:
                 cursor = db.execute(
                     'INSERT INTO tickets ('
-                    'customer_id, subject, description, status, product, issue_description, '
+                    'customer_id, subject, description, status, product, issue_description, payment_info, '
                     'repair_status, date_received, date_repaired, date_returned, created_by, last_modified_by'
-                    ') VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                    ') VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                     (
                         customer_id,
                         subject,
@@ -188,6 +190,7 @@ def create_app() -> Flask:
                         DEFAULT_TICKET_STATUS,
                         product or None,
                         issue_description or None,
+                        payment_info or None,
                         repair_status,
                         date_received,
                         date_repaired,
@@ -251,6 +254,7 @@ def create_app() -> Flask:
 
             product = request.form.get('product', '').strip() or None
             issue_description = request.form.get('issue_description', '').strip() or None
+            payment_info = request.form.get('payment_info', '').strip() or None
             repair_status = request.form.get(
                 'repair_status',
                 ticket['repair_status'] or DEFAULT_REPAIR_STATUS,
@@ -265,6 +269,7 @@ def create_app() -> Flask:
                 'status',
                 'product',
                 'issue_description',
+                'payment_info',
                 'repair_status',
                 'date_received',
                 'date_repaired',
@@ -274,6 +279,7 @@ def create_app() -> Flask:
                 'status': new_status,
                 'product': product,
                 'issue_description': issue_description,
+                'payment_info': payment_info,
                 'repair_status': repair_status,
                 'date_received': date_received,
                 'date_repaired': date_repaired,
@@ -288,7 +294,7 @@ def create_app() -> Flask:
 
             db.execute(
                 'UPDATE tickets SET '
-                'status = ?, product = ?, issue_description = ?, repair_status = ?, '
+                'status = ?, product = ?, issue_description = ?, payment_info = ?, repair_status = ?, '
                 'date_received = ?, date_repaired = ?, date_returned = ?, '
                 'last_modified_by = ?, updated_at = CURRENT_TIMESTAMP '
                 'WHERE id = ?',
@@ -296,6 +302,7 @@ def create_app() -> Flask:
                     new_status,
                     product,
                     issue_description,
+                    payment_info,
                     repair_status,
                     date_received,
                     date_repaired,

--- a/database.py
+++ b/database.py
@@ -59,6 +59,8 @@ def init_db():
         db.execute('ALTER TABLE tickets ADD COLUMN created_by INTEGER')
     if not _column_exists('tickets', 'last_modified_by'):
         db.execute('ALTER TABLE tickets ADD COLUMN last_modified_by INTEGER')
+    if not _column_exists('tickets', 'payment_info'):
+        db.execute('ALTER TABLE tickets ADD COLUMN payment_info TEXT')
 
     # Garantisce la presenza della tabella di storico modifiche.
     db.execute(

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS tickets (
     status TEXT NOT NULL DEFAULT 'open',
     product TEXT,
     issue_description TEXT,
+    payment_info TEXT,
     repair_status TEXT NOT NULL DEFAULT 'accettazione',
     date_received DATE,
     date_repaired DATE,

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -26,6 +26,9 @@
     <label for="issue_description">Descrizione problema</label>
     <textarea id="issue_description" name="issue_description" rows="4">{{ request.form.get('issue_description', '') }}</textarea>
 
+    <label for="payment_info">Informazioni pagamento</label>
+    <textarea id="payment_info" name="payment_info" rows="3" placeholder="Es. acconto, metodo di pagamento, note">{{ request.form.get('payment_info', '') }}</textarea>
+
     <label for="repair_status">Stato riparazione</label>
     <select id="repair_status" name="repair_status">
         {% for value, label in repair_statuses %}

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -43,6 +43,7 @@
         <th>Cliente</th>
         <th>Prodotto</th>
         <th>Descrizione problema</th>
+        <th>Pagamento</th>
         <th>Stato</th>
         <th>Ricevuto</th>
         <th>Riparato</th>
@@ -56,6 +57,7 @@
         <td>{{ repair['customer_name'] }}</td>
         <td>{{ repair['product'] or '-' }}</td>
         <td>{{ repair['issue_description'] or '-' }}</td>
+        <td>{{ repair['payment_info'] or '-' }}</td>
         {% set repair_status_slug = (repair['repair_status'] or '')|lower|replace(' ', '-')|replace('_', '-') %}
         <td>
             {% set status_label = repair_status_labels.get(repair['repair_status'], repair['repair_status'] or 'N/A') %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -17,6 +17,7 @@
 <ul>
     <li><strong>Oggetto:</strong> {{ ticket['subject'] }}</li>
     <li><strong>Descrizione:</strong> {{ ticket['description'] or 'N/A' }}</li>
+    <li><strong>Pagamento:</strong> {{ ticket['payment_info'] or 'N/A' }}</li>
     <li><strong>Creato il:</strong> {{ ticket['created_at'] }}</li>
     <li><strong>Creato da:</strong> {{ ticket['created_by_username'] or 'N/D' }}</li>
     <li>
@@ -41,6 +42,9 @@
 
     <label for="issue_description">Descrizione problema</label>
     <textarea id="issue_description" name="issue_description" rows="4" {% if not can_edit %}readonly{% endif %}>{{ ticket['issue_description'] or '' }}</textarea>
+
+    <label for="payment_info">Informazioni pagamento</label>
+    <textarea id="payment_info" name="payment_info" rows="3" {% if not can_edit %}readonly{% endif %}>{{ ticket['payment_info'] or '' }}</textarea>
 
     <label for="repair_status">Stato riparazione</label>
     <select id="repair_status" name="repair_status" {% if not can_edit %}disabled{% endif %}>


### PR DESCRIPTION
## Summary
- add the payment_info column to the tickets table and expose it in history tracking
- allow creating and updating payment information from the ticket creation and detail views
- display payment information in ticket details and the repairs listing

## Testing
- python -m compileall app.py database.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe9f72ca8832d9a98165bb978e6b9