### PR TITLE
Allow authenticated users to create and update tickets

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ funzionalità per la gestione di clienti, ticket e riparazioni.
 
 import os
 
-from flask import Flask, render_template, request, redirect, url_for, flash, abort
+from flask import Flask, render_template, request, redirect, url_for, flash
 from pathlib import Path
 from typing import Optional
 
@@ -157,7 +157,7 @@ def create_app() -> Flask:
 
     # Inserimento nuovo ticket
     @app.route('/tickets/new', methods=['GET', 'POST'])
-    @admin_required
+    @login_required
     def add_ticket():
         db = get_db()
         if request.method == 'POST':
@@ -241,8 +241,6 @@ def create_app() -> Flask:
             flash('Ticket non trovato.', 'error')
             return redirect(url_for('tickets'))
         if request.method == 'POST':
-            if not getattr(current_user, 'is_admin', False):
-                abort(403)
             current_user_id = int(current_user.id)
             new_status = request.form.get('status', '').strip() or ticket['status']
             if new_status not in TICKET_STATUS_VALUES:

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -2,7 +2,7 @@
 {% set ticket_number = '%04d'|format(ticket['id']) %}
 {% block title %}Ticket #{{ ticket_number }}{% endblock %}
 {% block content %}
-{% set can_edit = current_user.is_authenticated and current_user.is_admin %}
+{% set can_edit = current_user.is_authenticated %}
 <div class="ticket-header">
     <h2>Ticket #{{ ticket_number }}</h2>
     <div class="ticket-header-details">
@@ -58,11 +58,7 @@
     <label for="date_returned">Data consegna</label>
     <input type="date" id="date_returned" name="date_returned" value="{{ ticket['date_returned'] or '' }}" {% if not can_edit %}readonly{% endif %}>
 
-    {% if can_edit %}
-    <button type="submit">Salva modifiche</button>
-    {% else %}
-    <p class="info">Solo un amministratore può modificare lo stato del ticket e i dati di riparazione.</p>
-    {% endif %}
+    <button type="submit" {% if not can_edit %}disabled{% endif %}>Salva modifiche</button>
 </form>
 
 <section class="ticket-history">


### PR DESCRIPTION
## Summary
- allow any logged-in user to access the ticket creation form and submit updates
- remove the admin-only guard from ticket updates while keeping audit fields intact
- enable the ticket detail form controls for authenticated users in the template

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dfe9ebc6ec832dbaaba20f5f906c33