### PR TITLE
Add admin deletion routes and UI actions

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -68,6 +68,25 @@
             gap: 0.5rem 1rem;
             margin: 1rem 0;
         }
+        .actions-column {
+            text-align: center;
+            white-space: nowrap;
+        }
+        form.inline-form {
+            display: inline;
+            margin: 0;
+        }
+        form.inline-form button {
+            margin-top: 0;
+            display: inline-block;
+        }
+        .btn-danger {
+            background: #d32f2f;
+            border-radius: 4px;
+        }
+        .btn-danger:hover {
+            background: #9a0007;
+        }
     </style>
 </head>
 <body>

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -11,6 +11,9 @@
         <th>Email</th>
         <th>Telefono</th>
         <th>Indirizzo</th>
+        {% if current_user.is_authenticated and current_user.is_admin %}
+        <th class="actions-column">Azioni</th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -20,6 +23,19 @@
         <td>{{ customer['email'] or '-' }}</td>
         <td>{{ customer['phone'] or '-' }}</td>
         <td>{{ customer['address'] or '-' }}</td>
+        {% if current_user.is_authenticated and current_user.is_admin %}
+        <td class="actions-column">
+            <form method="post"
+                  action="{{ url_for('delete_customer', customer_id=customer['id']) }}"
+                  class="inline-form"
+                  onsubmit="return confirm('Confermi l\'eliminazione del cliente? Tutti i ticket associati verranno rimossi.');">
+                {% if csrf_token is defined %}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                {% endif %}
+                <button type="submit" class="btn-danger">Elimina</button>
+            </form>
+        </td>
+        {% endif %}
     </tr>
     {% endfor %}
     </tbody>

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -47,6 +47,9 @@
         <th>Ricevuto</th>
         <th>Riparato</th>
         <th>Consegnato</th>
+        {% if current_user.is_authenticated and current_user.is_admin %}
+        <th class="actions-column">Azioni</th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -64,6 +67,24 @@
         <td>{{ repair['date_received'] or '-' }}</td>
         <td>{{ repair['date_repaired'] or '-' }}</td>
         <td>{{ repair['date_returned'] or '-' }}</td>
+        {% if current_user.is_authenticated and current_user.is_admin %}
+        <td class="actions-column">
+            <form method="post"
+                  action="{{ url_for('delete_repair', ticket_id=repair['id']) }}"
+                  class="inline-form"
+                  onsubmit="return confirm('Confermi l\'eliminazione della riparazione? Il ticket verrà rimosso definitivamente.');">
+                {% if csrf_token is defined %}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                {% endif %}
+                {% if current_filters %}
+                    {% for filter_key, filter_value in current_filters.items() if filter_value %}
+                    <input type="hidden" name="filter_{{ filter_key }}" value="{{ filter_value }}">
+                    {% endfor %}
+                {% endif %}
+                <button type="submit" class="btn-danger">Elimina</button>
+            </form>
+        </td>
+        {% endif %}
     </tr>
     {% endfor %}
     </tbody>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -21,6 +21,9 @@
         <th>Cliente / Stato</th>
         <th>Oggetto</th>
         <th>Creato il</th>
+        {% if current_user.is_authenticated and current_user.is_admin %}
+        <th class="actions-column">Azioni</th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -36,6 +39,24 @@
         </td>
         <td>{{ ticket['subject'] }}</td>
         <td>{{ ticket['created_at'] }}</td>
+        {% if current_user.is_authenticated and current_user.is_admin %}
+        <td class="actions-column">
+            <form method="post"
+                  action="{{ url_for('delete_ticket', ticket_id=ticket['id']) }}"
+                  class="inline-form"
+                  onsubmit="return confirm('Confermi l\'eliminazione del ticket selezionato?');">
+                {% if csrf_token is defined %}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                {% endif %}
+                {% if current_filters %}
+                    {% for filter_key, filter_value in current_filters.items() if filter_value %}
+                    <input type="hidden" name="filter_{{ filter_key }}" value="{{ filter_value }}">
+                    {% endfor %}
+                {% endif %}
+                <button type="submit" class="btn-danger">Elimina</button>
+            </form>
+        </td>
+        {% endif %}
     </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- add admin-protected delete routes for customers, tickets, and repairs with confirmation messaging and filter-aware redirects
- expose delete actions in customer, ticket, and repair tables with POST forms, confirmation prompts, and optional CSRF tokens
- style inline action buttons to integrate with existing layout

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dfe9ecd6cc832d92cb359217d48636