### PR TITLE
Aggiungi gestione allegati ai ticket

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,15 +7,30 @@ funzionalità per la gestione di clienti, ticket e riparazioni.
 """
 
 import os
+import re
+import uuid
 
-from flask import Flask, render_template, request, redirect, url_for, flash, abort
+from flask import (
+    Flask,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    abort,
+    current_app,
+    send_from_directory,
+)
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Sequence
 
 from database import get_db, init_db, close_db
 from flask_login import current_user, login_required
 
 from auth import admin_required, bp as auth_bp, login_manager
+
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
 
 
 TICKET_STATUSES = [
@@ -47,7 +62,158 @@ TICKET_HISTORY_FIELD_LABELS = {
     'date_received': 'Data ricezione',
     'date_repaired': 'Data riparazione',
     'date_returned': 'Data consegna',
+    'attachments': 'Allegati',
 }
+
+
+def _parse_size(value: Optional[str], default: int) -> int:
+    """Converte una stringa di dimensione (es. "10MB") in byte."""
+
+    if not value:
+        return default
+    raw_value = value.strip()
+    if not raw_value:
+        return default
+    try:
+        return int(raw_value)
+    except ValueError:
+        match = re.match(r'^(?P<number>\d+)\s*(?P<unit>[KMG]B)?$', raw_value, flags=re.IGNORECASE)
+        if not match:
+            return default
+        number = int(match.group('number'))
+        unit = match.group('unit')
+        if not unit:
+            return number
+        unit = unit.upper()
+        multipliers = {
+            'KB': 1024,
+            'MB': 1024 ** 2,
+            'GB': 1024 ** 3,
+        }
+        return number * multipliers.get(unit, 1)
+
+
+def _get_allowed_extensions(raw: Optional[str]) -> List[str]:
+    """Restituisce la lista delle estensioni consentite normalizzate."""
+
+    if not raw:
+        return ['pdf', 'png', 'jpg', 'jpeg', 'gif', 'txt', 'doc', 'docx']
+    extensions = []
+    for item in raw.split(','):
+        normalized = item.strip().lstrip('.').lower()
+        if normalized:
+            extensions.append(normalized)
+    return extensions or ['pdf', 'png', 'jpg', 'jpeg', 'gif', 'txt', 'doc', 'docx']
+
+
+def _allowed_file(filename: str) -> bool:
+    """Verifica se il file ha un'estensione consentita."""
+
+    allowed_extensions = set(current_app.config.get('ALLOWED_EXTENSIONS', []))
+    if not allowed_extensions:
+        return True
+    if '.' not in filename:
+        return False
+    ext = filename.rsplit('.', 1)[1].lower()
+    return ext in allowed_extensions
+
+
+def _save_ticket_attachments(
+    ticket_id: int,
+    files: Sequence[FileStorage],
+    uploaded_by: int,
+    db,
+) -> List[str]:
+    """Salva gli allegati sul filesystem e registra i metadati sul database."""
+
+    saved_names: List[str] = []
+    upload_folder = Path(current_app.config['UPLOAD_FOLDER'])
+    max_file_size = current_app.config.get('MAX_FILE_SIZE')
+
+    for file in files:
+        if not file or not file.filename:
+            continue
+
+        original_name = file.filename
+        safe_name = secure_filename(original_name)
+        if not safe_name:
+            flash('Impossibile caricare un file con nome non valido.', 'error')
+            continue
+
+        if not _allowed_file(safe_name):
+            flash(f"Il file {original_name} ha un'estensione non consentita.", 'error')
+            continue
+
+        file_size = file.content_length
+        if file_size is None:
+            try:
+                file.stream.seek(0, os.SEEK_END)
+                file_size = file.stream.tell()
+            except (AttributeError, OSError):
+                file_size = None
+            finally:
+                try:
+                    file.stream.seek(0)
+                except (AttributeError, OSError):
+                    pass
+
+        if max_file_size and file_size and file_size > max_file_size:
+            max_mb = max_file_size / (1024 * 1024)
+            flash(
+                f"Il file {original_name} supera la dimensione massima consentita di {max_mb:.1f} MB.",
+                'error',
+            )
+            continue
+
+        unique_name = f"{uuid.uuid4().hex}_{safe_name}"
+        destination = upload_folder / unique_name
+
+        try:
+            file.stream.seek(0)
+            file.save(destination)
+        except OSError as exc:
+            current_app.logger.exception("Errore durante il salvataggio dell'allegato")
+            flash(f"Errore nel salvataggio dell'allegato {original_name}: {exc}", 'error')
+            continue
+
+        db.execute(
+            'INSERT INTO ticket_attachments (ticket_id, file_path, original_name, content_type, uploaded_by) '
+            'VALUES (?, ?, ?, ?, ?)',
+            (
+                ticket_id,
+                unique_name,
+                original_name,
+                file.mimetype or 'application/octet-stream',
+                uploaded_by,
+            ),
+        )
+        saved_names.append(original_name)
+
+    return saved_names
+
+
+def _delete_ticket_files(ticket_id: int, db) -> None:
+    """Rimuove dal filesystem gli allegati associati a un ticket."""
+
+    upload_folder = Path(current_app.config['UPLOAD_FOLDER'])
+    attachments = db.execute(
+        'SELECT id, file_path FROM ticket_attachments WHERE ticket_id = ?',
+        (ticket_id,),
+    ).fetchall()
+
+    for attachment in attachments:
+        file_path = upload_folder / attachment['file_path']
+        try:
+            if file_path.exists():
+                file_path.unlink()
+        except OSError as exc:
+            current_app.logger.warning(
+                "Impossibile eliminare l'allegato %s: %s",
+                file_path,
+                exc,
+            )
+
+    db.execute('DELETE FROM ticket_attachments WHERE ticket_id = ?', (ticket_id,))
 
 
 def create_app() -> Flask:
@@ -57,6 +223,26 @@ def create_app() -> Flask:
     app.config['SECRET_KEY'] = 'change-me-please'
     # Percorso del database: per default è nella stessa directory del file app
     app.config.setdefault('DATABASE', str(Path(app.root_path) / 'database.db'))
+
+    # Configurazione del filesystem per gli upload
+    instance_path = Path(app.instance_path)
+    instance_path.mkdir(parents=True, exist_ok=True)
+
+    upload_folder_env = os.environ.get('UPLOAD_FOLDER')
+    upload_folder = Path(upload_folder_env) if upload_folder_env else instance_path / 'uploads'
+    upload_folder.mkdir(parents=True, exist_ok=True)
+    app.config['UPLOAD_FOLDER'] = str(upload_folder)
+
+    max_content_length = _parse_size(os.environ.get('MAX_CONTENT_LENGTH'), 16 * 1024 * 1024)
+    app.config['MAX_CONTENT_LENGTH'] = max_content_length
+
+    max_file_size = _parse_size(os.environ.get('UPLOAD_MAX_FILE_SIZE'), max_content_length)
+    if max_file_size > max_content_length:
+        max_file_size = max_content_length
+    app.config['MAX_FILE_SIZE'] = max_file_size
+
+    allowed_extensions = set(_get_allowed_extensions(os.environ.get('UPLOAD_ALLOWED_EXTENSIONS')))
+    app.config['ALLOWED_EXTENSIONS'] = allowed_extensions
 
     login_manager.init_app(app)
 
@@ -211,6 +397,25 @@ def create_app() -> Flask:
                         current_user_id,
                     ),
                 )
+                attachments = request.files.getlist('attachments')
+                saved_attachment_names = _save_ticket_attachments(
+                    ticket_id,
+                    attachments,
+                    current_user_id,
+                    db,
+                )
+                if saved_attachment_names:
+                    db.execute(
+                        'INSERT INTO ticket_history (ticket_id, field, old_value, new_value, changed_by) '
+                        'VALUES (?, ?, ?, ?, ?)',
+                        (
+                            ticket_id,
+                            'attachments',
+                            None,
+                            'Aggiunti allegati: ' + ', '.join(saved_attachment_names),
+                            current_user_id,
+                        ),
+                    )
                 db.commit()
                 flash('Ticket creato con successo.', 'success')
                 return redirect(url_for('tickets'))
@@ -244,6 +449,10 @@ def create_app() -> Flask:
             if not getattr(current_user, 'is_admin', False):
                 abort(403)
             current_user_id = int(current_user.id)
+            attachments_files = request.files.getlist('attachments')
+            attempted_attachments = any(
+                file and getattr(file, 'filename', '') for file in attachments_files
+            )
             new_status = request.form.get('status', '').strip() or ticket['status']
             if new_status not in TICKET_STATUS_VALUES:
                 flash('Stato del ticket non valido.', 'error')
@@ -282,57 +491,86 @@ def create_app() -> Flask:
             has_changes = any(
                 (ticket[field] or '') != (new_values[field] or '') for field in tracked_fields
             )
-            if not has_changes:
-                flash('Nessuna modifica rilevata.', 'info')
-                return redirect(url_for('ticket_detail', ticket_id=ticket_id))
 
-            db.execute(
-                'UPDATE tickets SET '
-                'status = ?, product = ?, issue_description = ?, repair_status = ?, '
-                'date_received = ?, date_repaired = ?, date_returned = ?, '
-                'last_modified_by = ?, updated_at = CURRENT_TIMESTAMP '
-                'WHERE id = ?',
-                (
-                    new_status,
-                    product,
-                    issue_description,
-                    repair_status,
-                    date_received,
-                    date_repaired,
-                    date_returned,
-                    current_user_id,
-                    ticket_id,
-                ),
+            if has_changes:
+                db.execute(
+                    'UPDATE tickets SET '
+                    'status = ?, product = ?, issue_description = ?, repair_status = ?, '
+                    'date_received = ?, date_repaired = ?, date_returned = ?, '
+                    'last_modified_by = ?, updated_at = CURRENT_TIMESTAMP '
+                    'WHERE id = ?',
+                    (
+                        new_status,
+                        product,
+                        issue_description,
+                        repair_status,
+                        date_received,
+                        date_repaired,
+                        date_returned,
+                        current_user_id,
+                        ticket_id,
+                    ),
+                )
+
+                def _format_value(key: str, value):
+                    if value is None:
+                        return None
+                    if key == 'status':
+                        return TICKET_STATUS_LABELS.get(value, value)
+                    if key == 'repair_status':
+                        return REPAIR_STATUS_LABELS.get(value, value)
+                    return str(value)
+
+                for field in tracked_fields:
+                    old_raw = ticket[field]
+                    new_raw = new_values[field]
+                    if (old_raw or '') == (new_raw or ''):
+                        continue
+
+                    db.execute(
+                        'INSERT INTO ticket_history (ticket_id, field, old_value, new_value, changed_by) '
+                        'VALUES (?, ?, ?, ?, ?)',
+                        (
+                            ticket_id,
+                            field,
+                            _format_value(field, old_raw),
+                            _format_value(field, new_raw),
+                            current_user_id,
+                        ),
+                    )
+
+            saved_attachment_names = _save_ticket_attachments(
+                ticket_id,
+                attachments_files,
+                current_user_id,
+                db,
             )
 
-            def _format_value(key: str, value):
-                if value is None:
-                    return None
-                if key == 'status':
-                    return TICKET_STATUS_LABELS.get(value, value)
-                if key == 'repair_status':
-                    return REPAIR_STATUS_LABELS.get(value, value)
-                return str(value)
-
-            for field in tracked_fields:
-                old_raw = ticket[field]
-                new_raw = new_values[field]
-                if (old_raw or '') == (new_raw or ''):
-                    continue
-
+            if saved_attachment_names:
                 db.execute(
                     'INSERT INTO ticket_history (ticket_id, field, old_value, new_value, changed_by) '
                     'VALUES (?, ?, ?, ?, ?)',
                     (
                         ticket_id,
-                        field,
-                        _format_value(field, old_raw),
-                        _format_value(field, new_raw),
+                        'attachments',
+                        None,
+                        'Aggiunti allegati: ' + ', '.join(saved_attachment_names),
                         current_user_id,
                     ),
                 )
+
+            if not has_changes and not saved_attachment_names:
+                if not attempted_attachments:
+                    flash('Nessuna modifica rilevata.', 'info')
+                return redirect(url_for('ticket_detail', ticket_id=ticket_id))
+
             db.commit()
-            flash('Ticket aggiornato con successo.', 'success')
+            if has_changes and saved_attachment_names:
+                flash('Ticket aggiornato e allegati caricati con successo.', 'success')
+            elif has_changes:
+                flash('Ticket aggiornato con successo.', 'success')
+            else:
+                flash('Allegati caricati con successo.', 'success')
             return redirect(url_for('ticket_detail', ticket_id=ticket_id))
 
         history_entries = db.execute(
@@ -344,6 +582,14 @@ def create_app() -> Flask:
             'ORDER BY h.changed_at DESC, h.id DESC',
             (ticket_id,),
         ).fetchall()
+        attachments = db.execute(
+            'SELECT a.*, u.username AS uploaded_by_username '
+            'FROM ticket_attachments a '
+            'LEFT JOIN users u ON a.uploaded_by = u.id '
+            'WHERE a.ticket_id = ? '
+            'ORDER BY a.uploaded_at DESC, a.id DESC',
+            (ticket_id,),
+        ).fetchall()
         return render_template(
             'ticket_detail.html',
             ticket=ticket,
@@ -353,7 +599,53 @@ def create_app() -> Flask:
             repair_status_labels=REPAIR_STATUS_LABELS,
             history_entries=history_entries,
             ticket_history_field_labels=TICKET_HISTORY_FIELD_LABELS,
+            attachments=attachments,
         )
+
+    @app.route('/tickets/<int:ticket_id>/attachments/<int:attachment_id>')
+    @login_required
+    def download_ticket_attachment(ticket_id: int, attachment_id: int):
+        db = get_db()
+        attachment = db.execute(
+            'SELECT a.*, t.id AS ticket_id '
+            'FROM ticket_attachments a '
+            'JOIN tickets t ON a.ticket_id = t.id '
+            'WHERE a.id = ? AND a.ticket_id = ?',
+            (attachment_id, ticket_id),
+        ).fetchone()
+        if attachment is None:
+            abort(404)
+
+        file_path = Path(current_app.config['UPLOAD_FOLDER']) / attachment['file_path']
+        if not file_path.exists():
+            current_app.logger.warning(
+                "File allegato mancante: ticket %s, attachment %s",
+                ticket_id,
+                attachment_id,
+            )
+            abort(404)
+
+        return send_from_directory(
+            current_app.config['UPLOAD_FOLDER'],
+            attachment['file_path'],
+            as_attachment=True,
+            download_name=attachment['original_name'],
+        )
+
+    @app.route('/tickets/<int:ticket_id>/delete', methods=['POST'])
+    @admin_required
+    def delete_ticket(ticket_id: int):
+        db = get_db()
+        ticket = db.execute('SELECT id FROM tickets WHERE id = ?', (ticket_id,)).fetchone()
+        if ticket is None:
+            flash('Ticket non trovato.', 'error')
+            return redirect(url_for('tickets'))
+
+        _delete_ticket_files(ticket_id, db)
+        db.execute('DELETE FROM tickets WHERE id = ?', (ticket_id,))
+        db.commit()
+        flash('Ticket eliminato con successo.', 'success')
+        return redirect(url_for('tickets'))
 
     # Lista delle riparazioni
     @app.route('/repairs')

--- a/database.py
+++ b/database.py
@@ -75,4 +75,19 @@ def init_db():
         ')'
     )
 
+    # Tabella allegati: mantiene i metadati dei file salvati sul filesystem.
+    db.execute(
+        'CREATE TABLE IF NOT EXISTS ticket_attachments ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+        'ticket_id INTEGER NOT NULL, '
+        'file_path TEXT NOT NULL, '
+        'original_name TEXT NOT NULL, '
+        'content_type TEXT, '
+        'uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, '
+        'uploaded_by INTEGER, '
+        'FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE, '
+        'FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL'
+        ')'
+    )
+
     db.commit()

--- a/schema.sql
+++ b/schema.sql
@@ -52,3 +52,17 @@ CREATE TABLE IF NOT EXISTS ticket_history (
     FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
     FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE SET NULL
 );
+
+-- Allegati associati ai ticket.  I file vengono salvati sul filesystem mentre
+-- in questa tabella sono conservati i metadati necessari al download.
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id INTEGER NOT NULL,
+    file_path TEXT NOT NULL,
+    original_name TEXT NOT NULL,
+    content_type TEXT,
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    uploaded_by INTEGER,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
+    FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -2,7 +2,7 @@
 {% block title %}Nuovo ticket{% endblock %}
 {% block content %}
 <h2>Crea ticket</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
     <label for="customer_id">Cliente *</label>
     <select id="customer_id" name="customer_id" required>
         <option value="">-- seleziona --</option>
@@ -41,6 +41,9 @@
 
     <label for="date_returned">Data consegna</label>
     <input type="date" id="date_returned" name="date_returned" value="{{ request.form.get('date_returned', '') }}">
+
+    <label for="attachments">Allegati</label>
+    <input type="file" id="attachments" name="attachments" multiple>
 
     <button type="submit">Salva</button>
 </form>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -27,7 +27,29 @@
         {% endif %}
     </li>
 </ul>
-<form method="post" class="ticket-edit-form">
+<section class="ticket-attachments">
+    <h3>Allegati</h3>
+    {% if attachments %}
+    <ul class="attachment-list">
+        {% for attachment in attachments %}
+        <li>
+            <a href="{{ url_for('download_ticket_attachment', ticket_id=ticket['id'], attachment_id=attachment['id']) }}">
+                {{ attachment['original_name'] }}
+            </a>
+            <span class="meta">
+                Caricato il {{ attachment['uploaded_at'] }}
+                {% if attachment['uploaded_by_username'] %}
+                da {{ attachment['uploaded_by_username'] }}
+                {% endif %}
+            </span>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="info">Nessun allegato caricato per questo ticket.</p>
+    {% endif %}
+</section>
+<form method="post" class="ticket-edit-form" enctype="multipart/form-data">
     <label for="status">Stato ticket</label>
     <select id="status" name="status" {% if not can_edit %}disabled{% endif %}>
         {% for value, label in ticket_statuses %}
@@ -59,11 +81,18 @@
     <input type="date" id="date_returned" name="date_returned" value="{{ ticket['date_returned'] or '' }}" {% if not can_edit %}readonly{% endif %}>
 
     {% if can_edit %}
+    <label for="attachments">Aggiungi allegati</label>
+    <input type="file" id="attachments" name="attachments" multiple>
     <button type="submit">Salva modifiche</button>
     {% else %}
     <p class="info">Solo un amministratore può modificare lo stato del ticket e i dati di riparazione.</p>
     {% endif %}
 </form>
+{% if can_edit %}
+<form method="post" action="{{ url_for('delete_ticket', ticket_id=ticket['id']) }}" class="ticket-delete-form" onsubmit="return confirm('Confermi l\'eliminazione del ticket? Gli allegati verranno rimossi definitivamente.');">
+    <button type="submit" class="danger">Elimina ticket</button>
+</form>
+{% endif %}
 
 <section class="ticket-history">
     <h3>Storico modifiche</h3>


### PR DESCRIPTION
## Summary
- crea la tabella `ticket_attachments` e assicura la sua inizializzazione
- configura l'applicazione per gestire cartella, limiti e validazioni degli upload
- gestisce caricamento, download ed eliminazione degli allegati dalle viste dei ticket

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dfeaa57f3c832db06cfb45d26eba6d