### PR TITLE
Add ticket status selector and extend repair statuses

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ TICKET_STATUS_VALUES = set(TICKET_STATUS_LABELS)
 DEFAULT_TICKET_STATUS = TICKET_STATUSES[0][0]
 
 REPAIR_STATUSES = [
+    ("accettazione", "Accettazione"),
     ("diagnosticato", "Diagnosticato"),
     ("preventivo_pronto", "Preventivo pronto"),
     ("preventivo_accettato", "Preventivo accettato"),
@@ -221,6 +222,9 @@ def create_app() -> Flask:
             customer_id = request.form.get('customer_id')
             subject = request.form.get('subject', '').strip()
             description = request.form.get('description', '').strip()
+            ticket_status = request.form.get('ticket_status', DEFAULT_TICKET_STATUS)
+            if ticket_status not in TICKET_STATUS_VALUES:
+                ticket_status = DEFAULT_TICKET_STATUS
             product = request.form.get('product', '').strip()
             issue_description = request.form.get('issue_description', '').strip()
             payment_info = request.form.get('payment_info', '').strip()
@@ -242,7 +246,7 @@ def create_app() -> Flask:
                         customer_id,
                         subject,
                         description or None,
-                        DEFAULT_TICKET_STATUS,
+                        ticket_status,
                         product or None,
                         issue_description or None,
                         payment_info or None,
@@ -256,7 +260,7 @@ def create_app() -> Flask:
                 )
                 ticket_id = cursor.lastrowid
                 initial_status_label = TICKET_STATUS_LABELS.get(
-                    DEFAULT_TICKET_STATUS, DEFAULT_TICKET_STATUS
+                    ticket_status, ticket_status
                 )
                 db.execute(
                     'INSERT INTO ticket_history (ticket_id, field, old_value, new_value, changed_by) '
@@ -278,6 +282,7 @@ def create_app() -> Flask:
             'add_ticket.html',
             customers=customers,
             repair_statuses=REPAIR_STATUSES,
+            ticket_statuses=TICKET_STATUSES,
         )
 
     # Dettaglio ticket e aggiornamento stato

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -17,6 +17,14 @@
     <label for="description">Descrizione</label>
     <textarea id="description" name="description" rows="4"></textarea>
 
+    <label for="ticket_status">Stato ticket *</label>
+    <select id="ticket_status" name="ticket_status" required>
+        {% set default_ticket_status = ticket_statuses[0][0] %}
+        {% for value, label in ticket_statuses %}
+        <option value="{{ value }}" {% if request.form.get('ticket_status', default_ticket_status) == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+    </select>
+
     <h3>Dati riparazione</h3>
     <p class="info">Compila le informazioni se già disponibili; potrai aggiornarle successivamente dal dettaglio ticket.</p>
 


### PR DESCRIPTION
## Summary
- add the Accettazione choice to the repair status list
- allow choosing the ticket status during creation and store the selection

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dff1421984832db32fabe078001096