### PR TITLE
Add ticket attachments support

### DIFF
--- a/database.py
+++ b/database.py
@@ -77,4 +77,24 @@ def init_db():
         ')'
     )
 
+    # Tabella e indice per la gestione degli allegati dei ticket.
+    db.execute(
+        'CREATE TABLE IF NOT EXISTS ticket_attachments ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+        'ticket_id INTEGER NOT NULL, '
+        'original_filename TEXT NOT NULL, '
+        'stored_filename TEXT NOT NULL, '
+        'content_type TEXT, '
+        'file_size INTEGER, '
+        'uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, '
+        'uploaded_by INTEGER, '
+        'FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE, '
+        'FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL'
+        ')'
+    )
+    db.execute(
+        'CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket_id '
+        'ON ticket_attachments(ticket_id)'
+    )
+
     db.commit()

--- a/migrations/202406_add_ticket_attachments.sql
+++ b/migrations/202406_add_ticket_attachments.sql
@@ -1,0 +1,16 @@
+-- Aggiunge la tabella per gli allegati dei ticket e il relativo indice.
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id INTEGER NOT NULL,
+    original_filename TEXT NOT NULL,
+    stored_filename TEXT NOT NULL,
+    content_type TEXT,
+    file_size INTEGER,
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    uploaded_by INTEGER,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
+    FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket_id
+    ON ticket_attachments(ticket_id);

--- a/schema.sql
+++ b/schema.sql
@@ -53,3 +53,21 @@ CREATE TABLE IF NOT EXISTS ticket_history (
     FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
     FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE SET NULL
 );
+
+-- Allegati associati ai ticket. Conserva i metadati dei file caricati
+-- (nome originale, nome su disco, tipo MIME, dimensione e autore).
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id INTEGER NOT NULL,
+    original_filename TEXT NOT NULL,
+    stored_filename TEXT NOT NULL,
+    content_type TEXT,
+    file_size INTEGER,
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    uploaded_by INTEGER,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
+    FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket_id
+    ON ticket_attachments(ticket_id);

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -2,7 +2,7 @@
 {% block title %}Nuovo ticket{% endblock %}
 {% block content %}
 <h2>Crea ticket</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
     <label for="customer_id">Cliente *</label>
     <select id="customer_id" name="customer_id" required>
         <option value="">-- seleziona --</option>
@@ -52,6 +52,11 @@
 
     <label for="date_returned">Data consegna</label>
     <input type="date" id="date_returned" name="date_returned" value="{{ request.form.get('date_returned', '') }}">
+
+    <h3>Allegati</h3>
+    <p class="info">Puoi allegare immagini o documenti utili al ticket (dimensione massima 16&nbsp;MB per invio).</p>
+    <label for="attachments">Seleziona file</label>
+    <input type="file" id="attachments" name="attachments" multiple>
 
     <button type="submit">Salva</button>
 </form>

--- a/templates/base.html
+++ b/templates/base.html
@@ -88,6 +88,55 @@
         .btn-danger:hover {
             background: #9a0007;
         }
+        .ticket-attachments {
+            margin-top: 2rem;
+        }
+        .attachments-list {
+            list-style: none;
+            padding: 0;
+            margin: 1rem 0;
+        }
+        .attachments-list li {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.5rem 1rem;
+            padding: 0.75rem;
+            background: #fff;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        .attachment-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+        .attachment-meta {
+            font-size: 0.85rem;
+            color: #555;
+        }
+        .attachment-download {
+            color: #2d6cdf;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .attachment-download:hover {
+            text-decoration: underline;
+        }
+        .attachment-upload-form {
+            margin-top: 1rem;
+            padding: 1rem;
+            background: #fff;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        .attachment-upload-form label {
+            margin-top: 0;
+        }
+        .attachment-upload-form input[type="file"] {
+            padding: 0.25rem 0;
+        }
     </style>
 </head>
 <body>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -29,6 +29,7 @@
     </li>
 </ul>
 <form method="post" class="ticket-edit-form">
+    <input type="hidden" name="form_name" value="details">
     <label for="status">Stato ticket</label>
     <select id="status" name="status" {% if not can_edit %}disabled{% endif %}>
         {% for value, label in ticket_statuses %}
@@ -64,6 +65,41 @@
 
     <button type="submit" {% if not can_edit %}disabled{% endif %}>Salva modifiche</button>
 </form>
+
+<section class="ticket-attachments">
+    <h3>Allegati</h3>
+    {% if attachments %}
+    <ul class="attachments-list">
+        {% for attachment in attachments %}
+        <li>
+            <div class="attachment-info">
+                <strong>{{ attachment['original_filename'] }}</strong>
+                <span class="attachment-meta">
+                    {% if attachment['file_size'] %}
+                    ({{ (attachment['file_size'] / 1024)|round(1) }} KB)
+                    {% endif %}
+                    {% if attachment['uploaded_at'] %}
+                    &middot; {{ attachment['uploaded_at'] }}
+                    {% endif %}
+                    {% if attachment['uploaded_by_username'] %}
+                    &middot; {{ attachment['uploaded_by_username'] }}
+                    {% endif %}
+                </span>
+            </div>
+            <a class="attachment-download" href="{{ url_for('download_ticket_attachment', ticket_id=ticket['id'], attachment_id=attachment['id']) }}">Scarica</a>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="info">Nessun allegato presente per questo ticket.</p>
+    {% endif %}
+    <form method="post" enctype="multipart/form-data" class="attachment-upload-form">
+        <input type="hidden" name="form_name" value="attachments">
+        <label for="attachment_files">Aggiungi allegati</label>
+        <input type="file" id="attachment_files" name="attachments" multiple {% if not can_edit %}disabled{% endif %}>
+        <button type="submit" {% if not can_edit %}disabled{% endif %}>Carica allegati</button>
+    </form>
+</section>
 
 <section class="ticket-history">
     <h3>Storico modifiche</h3>


### PR DESCRIPTION
## Summary
- add backend support for uploading, storing and downloading ticket attachments with filesystem persistence
- create the ticket_attachments table and migration to track uploaded files and metadata
- update ticket creation/detail templates and styles to handle attachment uploads and display existing files

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dff3dc44fc832db68f69b23e09ad13