### PR TITLE
Add admin user promotion flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,6 +111,29 @@ def create_app() -> Flask:
         ).fetchall()
         return render_template('admin_users.html', users=users)
 
+    @app.route('/admin/users/<int:user_id>/promote', methods=['POST'])
+    @admin_required
+    def promote_user(user_id: int):
+        db = get_db()
+        user = db.execute(
+            'SELECT id, username, role FROM users WHERE id = ?',
+            (user_id,),
+        ).fetchone()
+
+        if user is None:
+            flash('Utente non trovato.', 'error')
+        elif user['role'] == 'admin':
+            flash(f"L'utente \"{user['username']}\" è già un amministratore.", 'info')
+        else:
+            db.execute("UPDATE users SET role = 'admin' WHERE id = ?", (user_id,))
+            db.commit()
+            flash(
+                f"L'utente \"{user['username']}\" è stato promosso ad amministratore.",
+                'success',
+            )
+
+        return redirect(url_for('admin_users'))
+
     # Lista clienti
     @app.route('/customers')
     @login_required

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -11,6 +11,7 @@
             <th>Nome utente</th>
             <th>Ruolo</th>
             <th>Creato il</th>
+            <th>Azioni</th>
         </tr>
     </thead>
     <tbody>
@@ -20,6 +21,15 @@
             <td>{{ user.username }}</td>
             <td>{{ user.role }}</td>
             <td>{{ user.created_at }}</td>
+            <td>
+                {% if user.role != 'admin' %}
+                <form method="post" action="{{ url_for('promote_user', user_id=user.id) }}" class="inline-form">
+                    <button type="submit">Rendi admin</button>
+                </form>
+                {% else %}
+                <span class="badge">Admin</span>
+                {% endif %}
+            </td>
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- add an admin-only route that promotes users to administrators with appropriate feedback
- extend the admin user list template with an action column to trigger promotions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff676cf70832da6e5dcb1b718fa13