### PR TITLE
Document deployment and backup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,40 @@ Questo gestionale è pensato come base da cui partire.  Alcune idee per evolverl
 - Inviare notifiche automatiche via email quando cambia lo stato di un ticket o una riparazione.
 
 Con questo progetto si ha una base funzionante che può essere adattata alle esigenze specifiche del proprio contesto.
+
+## Pubblicazione su un sito web esistente
+
+L’applicazione è sviluppata con Flask e necessita quindi di un server che possa eseguire codice Python lato backend.  Non può essere caricata direttamente come una semplice pagina HTML statica: per integrarla nel tuo sito devi ospitarla su un servizio che permetta processi Python (ad esempio un VPS, un servizio PaaS come Heroku/Render, oppure un server aziendale interno) e poi collegare il dominio del tuo sito all’istanza dell’applicazione tramite proxy o iframe.【F:app.py†L37-L82】
+
+Una configurazione tipica prevede:
+
+1. Distribuire il codice su un server con Python installato.
+2. Installare le dipendenze (`pip install -r requirements.txt`) e inizializzare il database come descritto sopra.
+3. Eseguire l’app con un application server (es. `gunicorn "app:create_app()"`) dietro a un reverse proxy Nginx/Apache che risponde al tuo dominio.
+4. Collegare dal sito principale un link o un iframe all’indirizzo pubblico dell’applicazione.
+
+Se il tuo sito è ospitato su un provider che offre solo hosting statico (solo HTML/CSS/JS), dovrai affiancare al sito una soluzione separata per il backend e poi integrare l’interfaccia del gestionale tramite link o embed.
+
+## Backup di database e allegati
+
+Il database predefinito è un file SQLite chiamato `database.db` nella cartella principale del progetto.  Gli allegati caricati nei ticket vengono salvati nella cartella `instance/uploads/`, con una sottocartella per ogni ticket, percorso configurabile tramite la variabile `UPLOAD_FOLDER` nell’applicazione.【F:app.py†L37-L118】
+
+Per eseguire un backup completo puoi:
+
+1. Fermare l’applicazione (o assicurarti che non stia scrivendo dati) per evitare file parziali.
+2. Copiare il file `database.db` e l’intera cartella `instance/uploads/` in una destinazione sicura (ad esempio un disco esterno, un NAS o un archivio cloud).
+3. Ripetere l’operazione periodicamente o automatizzarla con uno script/cron job.
+
+Su sistemi Linux puoi utilizzare un semplice script bash:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+DATA=$(date +%Y%m%d_%H%M)
+DEST="/percorso/del/backup/$DATA"
+mkdir -p "$DEST"
+cp -a database.db "$DEST/"
+cp -a instance/uploads "$DEST/uploads"
+```
+
+In questo modo manterrai una copia aggiornata sia dei dati strutturati sia dei documenti allegati ai ticket.


### PR DESCRIPTION
## Summary
- document how to host the Flask gestionale alongside an existing website and outline typical deployment steps
- explain how database and attachment backups work and provide an example shell script for periodic copies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3831b8f40832d834b26c8c2af07be