### PR TITLE
Improve OpenAI integration for AI suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Questo progetto è un semplice gestionale a ticket pensato per officine o centri
 
 ## Funzionalità principali
 
-- **Anagrafica clienti:** memorizza i dati anagrafici di ciascun cliente (nome, email, telefono, indirizzo) in modo da poterli richiamare rapidamente quando si crea un ticket【212499813267287†L162-L169】.
-- **Gestione dei ticket:** permette di aprire nuovi ticket, associare un cliente al ticket, inserire l’oggetto e la descrizione del problema, e aggiornarne lo stato (es. aperto, in lavorazione, risolto)【212499813267287†L150-L159】. Ogni ticket è identificato da un numero univoco e registra automaticamente la data di apertura【395316353871554†L139-L147】.
+- **Anagrafica clienti:** memorizza i dati anagrafici di ciascun cliente (nome, email, telefono, indirizzo) in modo da poterli richiamare rapidamente quando si crea un ticket.
+- **Gestione dei ticket:** permette di aprire nuovi ticket, associare un cliente al ticket, inserire l’oggetto e la descrizione del problema, e aggiornarne lo stato (es. aperto, in lavorazione, risolto). Ogni ticket è identificato da un numero univoco e registra automaticamente la data di apertura.
 - **Tracciamento delle riparazioni:** per interventi su hardware o dispositivi, è possibile registrare i dettagli della riparazione (prodotto, problema riscontrato, date di consegna/ritiro, ecc.) e aggiornare lo stato della riparazione (diagnosticato, preventivo pronto, preventivo accettato, intervento completato).
 - **Interfaccia web semplice:** l’applicazione fornisce pagine HTML con moduli per inserire e modificare dati e tabelle per visualizzare l’elenco di clienti, ticket e riparazioni.  In futuro è possibile espanderla con funzionalità di ricerca, assegnazione a tecnici specifici o invio di email ai clienti.
 
@@ -137,9 +137,9 @@ Per verificare la corretta gestione dei campi obbligatori nella creazione di una
 Questo gestionale è pensato come base da cui partire.  Alcune idee per evolverlo:
 
 - Implementare l’autenticazione per gli operatori (login e autorizzazioni).
-- Aggiungere la gestione dei tecnici e l’assegnazione dei ticket a persone specifiche【212499813267287†L170-L176】.
+- Aggiungere la gestione dei tecnici e l’assegnazione dei ticket a persone specifiche.
 - Integrare funzioni di ricerca e filtri avanzati per lo stato dei ticket o la cronologia dei clienti.
-- Esportare report e statistiche sui tempi di risoluzione, volume di ticket e prestazioni degli operatori【395316353871554†L210-L276】.
+- Esportare report e statistiche sui tempi di risoluzione, volume di ticket e prestazioni degli operatori.
 - Inviare notifiche automatiche via email quando cambia lo stato di un ticket o una riparazione.
 
 Con questo progetto si ha una base funzionante che può essere adattata alle esigenze specifiche del proprio contesto.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,69 @@ Questo progetto è un semplice gestionale a ticket pensato per officine o centri
 
    Per impostazione predefinita l’applicazione è disponibile all’indirizzo `http://127.0.0.1:5000/`.
 
+## Configurare le risposte dell'AI
+
+Il pulsante **Chiedi all’AI** invia una richiesta POST all’endpoint `/ai/suggest`. L’applicazione, a sua volta, inoltra i dettagli del ticket a un servizio esterno o a OpenAI per ottenere un consiglio tecnico sintetico e professionale. È possibile configurare l’integrazione in due modi:
+
+1. **Variabili d’ambiente** – impostare i parametri prima di avviare Flask:
+
+   ```bash
+   export AI_SUGGESTION_ENDPOINT="https://example.com/api/suggest"
+   export AI_SUGGESTION_TOKEN="il-tuo-token-opzionale"
+   export AI_SUGGESTION_TIMEOUT=20  # secondi, opzionale
+   flask --app app.py run --reload
+   ```
+
+2. **File di configurazione** – creare `instance/config.py` (la cartella viene generata automaticamente al primo avvio) con i valori desiderati:
+
+   ```python
+   AI_SUGGESTION_ENDPOINT = "https://example.com/api/suggest"
+   AI_SUGGESTION_TOKEN = "il-tuo-token-opzionale"
+   AI_SUGGESTION_TIMEOUT = 20
+   ```
+
+### Utilizzare direttamente OpenAI
+
+Se preferisci sfruttare l’API di OpenAI (chiave in formato `sk-...`) senza dover esporre un servizio intermedio, imposta il provider `openai`. Quando troviamo automaticamente una chiave che inizia con `sk-` e non hai specificato un provider, l’applicazione sceglie da sola quello OpenAI. Le richieste utilizzano il nuovo endpoint **Responses API** con il modello `gpt-4o-mini` e un prompt di sistema che istruisce il modello ad agire come "un tecnico di elettrodomestici esperto che fa diagnosi in maniera sintetica e professionale".
+
+```bash
+export AI_SUGGESTION_PROVIDER=openai          # facoltativo se la chiave è in formato sk-...
+export AI_SUGGESTION_TOKEN="sk-..."           # oppure usa OPENAI_API_KEY
+# export OPENAI_API_KEY="sk-..."             # se preferisci non configurare AI_SUGGESTION_TOKEN
+# export AI_SUGGESTION_OPENAI_MODEL="gpt-4o-mini"  # cambia modello se necessario
+# export AI_SUGGESTION_OPENAI_BASE_URL="https://api.openai.com/v1"
+# export AI_SUGGESTION_OPENAI_AUTH_HEADER="Authorization"  # es. "api-key" per Azure OpenAI
+# export AI_SUGGESTION_OPENAI_ORG="org_..."   # opzionale, se usi organizzazioni OpenAI
+flask --app app.py run --reload
+```
+
+L’app prova prima l’endpoint `/responses` e, se il modello richiede ancora l’interfaccia classica, effettua il fallback automatico a `/chat/completions`. È possibile personalizzare il messaggio di sistema impostando `AI_SUGGESTION_SYSTEM_PROMPT` via variabile d’ambiente o nel file `instance/config.py`.
+
+### Payload per servizi personalizzati
+
+Se utilizzi un endpoint personalizzato, il servizio riceve un payload come questo:
+
+```json
+{
+  "target": "issue_description",
+  "subject": "Notebook HP",
+  "product": "HP ProBook 450",
+  "issue_description": "Schermo che lampeggia in modo intermittente",
+  "description": "Il cliente segnala che il problema si presenta dopo qualche minuto di utilizzo.",
+  "requested_by": "nome_utente"
+}
+```
+
+La risposta deve restituire un campo `suggestion`, ad esempio:
+
+```json
+{
+  "suggestion": "Verificare i driver della scheda video e testare con un monitor esterno." 
+}
+```
+
+Se l’endpoint non è configurato l’applicazione mostra l’errore “Servizio AI non configurato”.
+
 ### Aggiornamento degli stati di riparazione esistenti
 
 Se stai aggiornando un database già in uso, esegui lo script nella cartella `migrations/` per rimappare i vecchi stati (`accettazione`, `preventivo`, `pronta`, `riconsegnata`, ecc.) sui nuovi valori.  Questo evita discrepanze tra i dati salvati e le nuove opzioni disponibili nell’interfaccia.

--- a/app.py
+++ b/app.py
@@ -42,6 +42,45 @@ REPAIR_STATUS_LABELS = {value: label for value, label in REPAIR_STATUSES}
 REPAIR_STATUS_VALUES = set(REPAIR_STATUS_LABELS)
 DEFAULT_REPAIR_STATUS = REPAIR_STATUSES[0][0]
 
+
+def _extract_openai_responses_text(data: dict) -> str:
+    """Estrae il testo utile dalla risposta dell'endpoint /responses di OpenAI."""
+
+    fragments: List[str] = []
+
+    def _push(value: Optional[str]) -> None:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                fragments.append(stripped)
+
+    output = data.get('output')
+    if isinstance(output, list):
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+
+            _push(item.get('text'))
+            _push(item.get('output_text'))
+
+            content = item.get('content')
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        block_type = (block.get('type') or '').lower()
+                        if block_type in {'output_text', 'text'}:
+                            _push(block.get('text'))
+                        else:
+                            _push(block.get('content'))
+                    else:
+                        _push(str(block))
+            else:
+                _push(content)
+
+    _push(data.get('output_text'))
+
+    return '\n'.join(fragments).strip()
+
 TICKET_HISTORY_FIELD_LABELS = {
     '__created__': 'Creazione ticket',
     'status': 'Stato ticket',
@@ -806,20 +845,10 @@ def create_app() -> Flask:
                     return jsonify({'error': message or 'Errore dal servizio OpenAI.'}), 502
 
                 if endpoint_suffix == 'responses':
-                    output = data.get('output') or []
-                    fragments = []
-                    for item in output:
-                        if not isinstance(item, dict):
-                            continue
-                        if item.get('type') == 'output_text' and item.get('text'):
-                            fragments.append(item['text'])
-                        elif isinstance(item.get('content'), str):
-                            fragments.append(item['content'])
-                    if not fragments:
-                        result = data.get('output_text')
-                        if isinstance(result, str):
-                            fragments.append(result)
-                    suggestion = '\n'.join(fragment.strip() for fragment in fragments if fragment).strip()
+                    suggestion = _extract_openai_responses_text(data)
+                    if not suggestion:
+                        openai_errors.append('Risposta vuota dal servizio OpenAI (endpoint responses).')
+                        continue
                 else:
                     choices = data.get('choices') or []
                     if choices:


### PR DESCRIPTION
## Summary
- default the AI integration to the new OpenAI Responses API with gpt-4o-mini and auto-detect sk- keys
- add configuration overrides for OpenAI base URL, auth header, and organization plus fallback to chat/completions when needed
- document the updated setup steps, including the new environment variables and automatic provider selection

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e383534330832dac730c2a70b4e6f2