### PR TITLE
Enable customer editing and ticket customer autocomplete

### DIFF
--- a/templates/add_customer.html
+++ b/templates/add_customer.html
@@ -1,20 +1,23 @@
 {% extends 'base.html' %}
-{% block title %}Nuovo cliente{% endblock %}
+{% set customer_record = customer if customer is defined else None %}
+{% set is_edit_flag = is_edit if is_edit is defined else False %}
+{% set editing = is_edit_flag or customer_record %}
+{% block title %}{{ 'Modifica cliente' if editing else 'Nuovo cliente' }}{% endblock %}
 {% block content %}
-<h2>Aggiungi cliente</h2>
+<h2>{{ 'Modifica cliente' if editing else 'Aggiungi cliente' }}</h2>
 <form method="post">
     <label for="name">Nome *</label>
-    <input type="text" id="name" name="name" required>
+    <input type="text" id="name" name="name" required value="{{ request.form.get('name', customer_record['name'] if customer_record else '') }}">
 
     <label for="email">Email</label>
-    <input type="email" id="email" name="email">
+    <input type="email" id="email" name="email" value="{{ request.form.get('email', customer_record['email'] if customer_record else '') }}">
 
     <label for="phone">Telefono</label>
-    <input type="text" id="phone" name="phone">
+    <input type="text" id="phone" name="phone" value="{{ request.form.get('phone', customer_record['phone'] if customer_record else '') }}">
 
     <label for="address">Indirizzo</label>
-    <textarea id="address" name="address" rows="3"></textarea>
+    <textarea id="address" name="address" rows="3">{{ request.form.get('address', customer_record['address'] if customer_record else '') }}</textarea>
 
-    <button type="submit">Salva</button>
+    <button type="submit">{{ 'Aggiorna' if editing else 'Salva' }}</button>
 </form>
 {% endblock %}

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -3,13 +3,29 @@
 {% block content %}
 <h2>Crea ticket</h2>
 <form method="post" enctype="multipart/form-data">
-    <label for="customer_id">Cliente *</label>
-    <select id="customer_id" name="customer_id" required>
-        <option value="">-- seleziona --</option>
+    <label for="customer_search">Cliente *</label>
+    <input type="hidden" id="customer_id" data-name="customer_id" value="{{ request.form.get('customer_id', '') }}">
+    <input type="text"
+           id="customer_search"
+           name="customer_search"
+           list="customer_list"
+           placeholder="Inizia a digitare per cercare un cliente"
+           autocomplete="off"
+           required
+           value="{{ request.form.get('customer_search', '') }}">
+    <datalist id="customer_list">
         {% for customer in customers %}
-        <option value="{{ customer['id'] }}">{{ customer['name'] }}</option>
+        <option value="{{ customer['name'] }}" data-id="{{ customer['id'] }}"></option>
         {% endfor %}
-    </select>
+    </datalist>
+    <noscript>
+        <select id="customer_id_noscript" name="customer_id" required>
+            <option value="">-- seleziona --</option>
+            {% for customer in customers %}
+            <option value="{{ customer['id'] }}">{{ customer['name'] }}</option>
+            {% endfor %}
+        </select>
+    </noscript>
 
     <label for="subject">Oggetto *</label>
     <input type="text" id="subject" name="subject" required>
@@ -66,4 +82,65 @@
 
     <button type="submit">Salva</button>
 </form>
+<script>
+    (function() {
+        const searchInput = document.getElementById('customer_search');
+        const hiddenInput = document.getElementById('customer_id');
+        const datalist = document.getElementById('customer_list');
+        if (!searchInput || !hiddenInput || !datalist) {
+            return;
+        }
+
+        hiddenInput.name = hiddenInput.dataset.name || 'customer_id';
+
+        const options = Array.from(datalist.options);
+
+        function findOptionByValue(value) {
+            const normalized = value.trim().toLowerCase();
+            if (!normalized) {
+                return null;
+            }
+            return options.find((option) => option.value.trim().toLowerCase() === normalized) || null;
+        }
+
+        function updateHiddenFromSearch() {
+            const match = findOptionByValue(searchInput.value);
+            if (match) {
+                hiddenInput.value = match.dataset.id || '';
+                searchInput.setCustomValidity('');
+            } else {
+                hiddenInput.value = '';
+                if (searchInput.value.trim()) {
+                    searchInput.setCustomValidity('Seleziona un cliente dall\'elenco.');
+                } else {
+                    searchInput.setCustomValidity('Questo campo è obbligatorio.');
+                }
+            }
+        }
+
+        searchInput.addEventListener('change', updateHiddenFromSearch);
+        searchInput.addEventListener('input', () => {
+            hiddenInput.value = '';
+            searchInput.setCustomValidity('');
+        });
+
+        const form = searchInput.form;
+        if (form) {
+            form.addEventListener('submit', (event) => {
+                updateHiddenFromSearch();
+                if (!hiddenInput.value) {
+                    event.preventDefault();
+                    searchInput.reportValidity();
+                }
+            });
+        }
+
+        if (hiddenInput.value) {
+            const current = options.find((option) => option.dataset.id === hiddenInput.value);
+            if (current) {
+                searchInput.value = current.value;
+            }
+        }
+    })();
+</script>
 {% endblock %}

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -25,6 +25,7 @@
         <td>{{ customer['address'] or '-' }}</td>
         {% if current_user.is_authenticated and current_user.is_admin %}
         <td class="actions-column">
+            <a class="button" href="{{ url_for('edit_customer', customer_id=customer['id']) }}" style="margin-right: 0.5rem;">Modifica</a>
             <form method="post"
                   action="{{ url_for('delete_customer', customer_id=customer['id']) }}"
                   class="inline-form"


### PR DESCRIPTION
## Summary
- add an admin-only route and form handling to update existing customer records
- surface a "Modifica" action beside each customer row to access the edit flow
- switch the ticket creation customer selector to an assisted autocomplete field with validation

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c099ddac832d9feed0764a8429c7