### PR TITLE
Show last ticket status changes with metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,6 +143,46 @@ TICKET_HISTORY_FIELD_LABELS = {
 }
 
 
+def _fetch_latest_ticket_history_entries(
+    db,
+    ticket_ids: Iterable[int],
+    fields: Iterable[str],
+):
+    """Recupera l'ultima modifica registrata per i campi richiesti."""
+
+    unique_ids = [int(ticket_id) for ticket_id in dict.fromkeys(ticket_ids) if ticket_id]
+    unique_fields = [field for field in dict.fromkeys(fields) if field]
+
+    latest = {field: {} for field in unique_fields}
+
+    if not unique_ids or not unique_fields:
+        return latest
+
+    placeholders_ids = ','.join('?' for _ in unique_ids)
+    placeholders_fields = ','.join('?' for _ in unique_fields)
+
+    rows = db.execute(
+        f'''\
+        SELECT h.ticket_id, h.field, h.old_value, h.new_value, h.changed_at, u.username AS changed_by_username
+        FROM ticket_history h
+        LEFT JOIN users u ON h.changed_by = u.id
+        WHERE h.ticket_id IN ({placeholders_ids})
+          AND h.field IN ({placeholders_fields})
+        ORDER BY h.changed_at DESC, h.id DESC
+        ''',
+        (*unique_ids, *unique_fields),
+    ).fetchall()
+
+    for row in rows:
+        field = row['field']
+        ticket_id = row['ticket_id']
+        field_map = latest.setdefault(field, {})
+        if ticket_id not in field_map:
+            field_map[ticket_id] = row
+
+    return latest
+
+
 def create_app() -> Flask:
     """Factory per creare e configurare l'istanza di Flask."""
     app = Flask(__name__, instance_relative_config=True)
@@ -389,8 +429,13 @@ def create_app() -> Flask:
         db = get_db()
         selected_status = request.args.get('status', '').strip()
         query = (
-            'SELECT t.*, c.name AS customer_name '
-            'FROM tickets t JOIN customers c ON t.customer_id = c.id '
+            'SELECT t.*, c.name AS customer_name, '
+            'creator.username AS created_by_username, '
+            'modifier.username AS last_modified_by_username '
+            'FROM tickets t '
+            'JOIN customers c ON t.customer_id = c.id '
+            'LEFT JOIN users creator ON t.created_by = creator.id '
+            'LEFT JOIN users modifier ON t.last_modified_by = modifier.id '
         )
         params = ()
         if selected_status:
@@ -401,6 +446,13 @@ def create_app() -> Flask:
                 selected_status = None
         query += 'ORDER BY t.created_at DESC'
         tickets = db.execute(query, params).fetchall()
+
+        latest_history_entries = _fetch_latest_ticket_history_entries(
+            db,
+            (ticket['id'] for ticket in tickets),
+            ('status',),
+        )
+
         current_filters = {'status': selected_status} if selected_status else {}
         return render_template(
             'tickets.html',
@@ -409,6 +461,7 @@ def create_app() -> Flask:
             ticket_status_labels=TICKET_STATUS_LABELS,
             selected_status=selected_status,
             current_filters=current_filters,
+            latest_history_entries=latest_history_entries,
         )
 
     @app.route('/tickets/<int:ticket_id>/delete', methods=['POST'])
@@ -655,6 +708,12 @@ def create_app() -> Flask:
             flash('Ticket aggiornato con successo.', 'success')
             return redirect(url_for('ticket_detail', ticket_id=ticket_id))
 
+        latest_history_entries = _fetch_latest_ticket_history_entries(
+            db,
+            (ticket_id,),
+            ('status', 'repair_status'),
+        )
+
         attachments = db.execute(
             'SELECT a.id, a.original_filename, a.stored_filename, a.content_type, a.file_size, '
             'a.uploaded_at, u.username AS uploaded_by_username '
@@ -684,6 +743,8 @@ def create_app() -> Flask:
             history_entries=history_entries,
             attachments=attachments,
             ticket_history_field_labels=TICKET_HISTORY_FIELD_LABELS,
+            last_status_change=latest_history_entries.get('status', {}).get(ticket_id),
+            last_repair_status_change=latest_history_entries.get('repair_status', {}).get(ticket_id),
         )
 
     @app.route('/tickets/<int:ticket_id>/attachments/<int:attachment_id>/download')
@@ -923,13 +984,23 @@ def create_app() -> Flask:
         where_clause = ' WHERE ' + ' AND '.join(filters) if filters else ''
 
         query = (
-            'SELECT t.*, c.name AS customer_name '
+            'SELECT t.*, c.name AS customer_name, '
+            'creator.username AS created_by_username, '
+            'modifier.username AS last_modified_by_username '
             'FROM tickets t '
             'JOIN customers c ON t.customer_id = c.id '
+            'LEFT JOIN users creator ON t.created_by = creator.id '
+            'LEFT JOIN users modifier ON t.last_modified_by = modifier.id '
             f'{where_clause} '
             'ORDER BY COALESCE(t.date_returned, t.updated_at) DESC, t.id DESC'
         )
         repairs = db.execute(query, params).fetchall()
+
+        latest_history_entries = _fetch_latest_ticket_history_entries(
+            db,
+            (repair['id'] for repair in repairs),
+            ('repair_status',),
+        )
 
         current_filters = {
             'status': selected_status,
@@ -943,6 +1014,7 @@ def create_app() -> Flask:
             repair_status_labels=REPAIR_STATUS_LABELS,
             repair_statuses=REPAIR_STATUSES,
             current_filters=current_filters,
+            latest_history_entries=latest_history_entries,
         )
 
     @app.route('/repairs/<int:ticket_id>/delete', methods=['POST'])

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -66,6 +66,14 @@
         <td>
             {% set status_label = repair_status_labels.get(repair['repair_status'], repair['repair_status'] or 'N/A') %}
             <span class="badge badge-{{ repair_status_slug if repair_status_slug else 'pending' }}">{{ status_label }}</span>
+            {% set status_change = (latest_history_entries.get('repair_status') or {}).get(repair['id']) %}
+            <div class="status-meta">
+                {% if status_change %}
+                <small>Aggiornato il {{ status_change['changed_at'] }}{% if status_change['changed_by_username'] %} da {{ status_change['changed_by_username'] }}{% endif %}</small>
+                {% else %}
+                <small>Creato il {{ repair['created_at'] }}{% if repair['created_by_username'] %} da {{ repair['created_by_username'] }}{% endif %}</small>
+                {% endif %}
+            </div>
         </td>
         <td>{{ repair['date_received'] or '-' }}</td>
         <td>{{ repair['date_repaired'] or '-' }}</td>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -11,6 +11,11 @@
             <strong>Stato:</strong>
             {% set status_slug = ticket['status']|replace('_', '-') %}
             <span class="badge badge-{{ status_slug }}">{{ ticket_status_labels.get(ticket['status'], ticket['status']) }}</span>
+            {% if last_status_change %}
+            <div class="status-meta">
+                <small>Ultimo cambio: {{ last_status_change['changed_at'] }}{% if last_status_change['changed_by_username'] %} ({{ last_status_change['changed_by_username'] }}){% endif %}</small>
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>
@@ -59,6 +64,11 @@
         <option value="{{ value }}" {% if ticket['repair_status'] == value %}selected{% endif %}>{{ label }}</option>
         {% endfor %}
     </select>
+    {% if last_repair_status_change %}
+    <p class="status-meta">
+        <small>Ultimo cambio: {{ last_repair_status_change['changed_at'] }}{% if last_repair_status_change['changed_by_username'] %} ({{ last_repair_status_change['changed_by_username'] }}){% endif %}</small>
+    </p>
+    {% endif %}
 
     <label for="date_received">Data ricezione</label>
     <input type="date" id="date_received" name="date_received" value="{{ ticket['date_received'] or '' }}" {% if not can_edit %}readonly{% endif %}>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -36,6 +36,14 @@
             <div class="ticket-status">
                 <span class="badge badge-{{ status_slug }}">{{ ticket_status_labels.get(ticket['status'], ticket['status']) }}</span>
             </div>
+            {% set status_change = (latest_history_entries.get('status') or {}).get(ticket['id']) %}
+            <div class="status-meta">
+                {% if status_change %}
+                <small>Aggiornato il {{ status_change['changed_at'] }}{% if status_change['changed_by_username'] %} da {{ status_change['changed_by_username'] }}{% endif %}</small>
+                {% else %}
+                <small>Creato il {{ ticket['created_at'] }}{% if ticket['created_by_username'] %} da {{ ticket['created_by_username'] }}{% endif %}</small>
+                {% endif %}
+            </div>
         </td>
         <td>{{ ticket['subject'] }}</td>
         <td>{{ ticket['created_at'] }}</td>


### PR DESCRIPTION
## Summary
- add a reusable helper to fetch the most recent ticket history entries for selected fields
- expose last status and repair-status change details across ticket listings and ticket detail pages
- surface user and timestamp information when no changes exist by falling back to ticket creation metadata

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c0cb1ac8832d9397037dd4726b8e