### PR TITLE
Add sequential customer codes and surface them in UI

### DIFF
--- a/migrations/202407_add_customer_codes.sql
+++ b/migrations/202407_add_customer_codes.sql
@@ -1,0 +1,22 @@
+-- Aggiunge il codice cliente di 4 caratteri e popola i valori esistenti.
+ALTER TABLE customers ADD COLUMN code TEXT;
+
+WITH ordered AS (
+    SELECT id,
+           ROW_NUMBER() OVER (ORDER BY id) - 1 AS rn
+    FROM customers
+)
+UPDATE customers
+SET code = (
+    SELECT char(
+        97 + ((rn / 17576) % 26),
+        97 + ((rn / 676) % 26),
+        97 + ((rn / 26) % 26),
+        97 + (rn % 26)
+    )
+    FROM ordered
+    WHERE ordered.id = customers.id
+)
+WHERE code IS NULL OR code = '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customers_code ON customers(code);

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS users (
 -- Tabella clienti.  Ogni cliente ha un identificativo univoco e dati anagrafici.
 CREATE TABLE IF NOT EXISTS customers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code TEXT NOT NULL UNIQUE,
     name TEXT NOT NULL,
     email TEXT,
     phone TEXT,

--- a/templates/add_ticket.html
+++ b/templates/add_ticket.html
@@ -7,7 +7,7 @@
     <select id="customer_id" name="customer_id" required>
         <option value="">-- seleziona --</option>
         {% for customer in customers %}
-        <option value="{{ customer['id'] }}">{{ customer['name'] }}</option>
+        <option value="{{ customer['id'] }}">{{ customer['code']|upper }} - {{ customer['name'] }}</option>
         {% endfor %}
     </select>
 

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -7,6 +7,7 @@
 <table>
     <thead>
     <tr>
+        <th>Codice</th>
         <th>Nome</th>
         <th>Email</th>
         <th>Telefono</th>
@@ -19,6 +20,7 @@
     <tbody>
     {% for customer in customers %}
     <tr>
+        <td class="customer-code">{{ customer['code']|upper }}</td>
         <td>{{ customer['name'] }}</td>
         <td>{{ customer['email'] or '-' }}</td>
         <td>{{ customer['phone'] or '-' }}</td>

--- a/templates/repairs.html
+++ b/templates/repairs.html
@@ -58,7 +58,7 @@
     {% for repair in repairs %}
     <tr>
         <td><a href="{{ url_for('ticket_detail', ticket_id=repair['id']) }}">{{ '%04d'|format(repair['id']) }} - {{ repair['subject'] }}</a></td>
-        <td>{{ repair['customer_name'] }}</td>
+        <td>{{ repair['customer_code']|upper }} - {{ repair['customer_name'] }}</td>
         <td>{{ repair['product'] or '-' }}</td>
         <td>{{ repair['issue_description'] or '-' }}</td>
         <td>{{ repair['payment_info'] or '-' }}</td>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -6,7 +6,7 @@
 <div class="ticket-header">
     <h2>Ticket #{{ ticket_number }}</h2>
     <div class="ticket-header-details">
-        <div><strong>Cliente:</strong> {{ ticket['customer_name'] }}</div>
+        <div><strong>Cliente:</strong> {{ ticket['customer_code']|upper }} - {{ ticket['customer_name'] }}</div>
         <div>
             <strong>Stato:</strong>
             {% set status_slug = ticket['status']|replace('_', '-') %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -31,7 +31,7 @@
     <tr>
         <td><a href="{{ url_for('ticket_detail', ticket_id=ticket['id']) }}">{{ '%04d'|format(ticket['id']) }}</a></td>
         <td>
-            <div class="ticket-customer">{{ ticket['customer_name'] }}</div>
+            <div class="ticket-customer">{{ ticket['customer_code']|upper }} - {{ ticket['customer_name'] }}</div>
             {% set status_slug = ticket['status']|replace('_', '-') %}
             <div class="ticket-status">
                 <span class="badge badge-{{ status_slug }}">{{ ticket_status_labels.get(ticket['status'], ticket['status']) }}</span>


### PR DESCRIPTION
## Summary
- add automatic four-letter customer codes with helper utilities and database enforcement
- display customer codes across creation forms, ticket listings, and detail views
- add schema changes and a migration to backfill existing customers with sequential codes

## Testing
- python -m compileall app.py database.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c10a073c832dbe6eadd41773e811