### PR TITLE
Use local server OAuth flow for Google Calendar

### DIFF
--- a/auth/google_calendar.py
+++ b/auth/google_calendar.py
@@ -74,10 +74,9 @@ class GoogleCalendarOAuth:
         flow = InstalledAppFlow.from_client_secrets_file(
             str(self.client_secrets_file), scopes=self.scopes
         )
-        if self.run_console:
-            credentials = flow.run_console()
-        else:
-            credentials = flow.run_local_server(port=self.local_server_port or 0)
+        # run_console è stato rimosso nelle versioni recenti di google-auth-oauthlib,
+        # usiamo sempre il flusso con server locale.
+        credentials = flow.run_local_server(port=self.local_server_port or 0)
         self._persist_credentials(credentials)
         return credentials
 


### PR DESCRIPTION
## Summary
- remove usage of deprecated `run_console` in OAuth flow
- always use the local server OAuth flow and persist credentials

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca513c5b4832d8e0635c8b5081ced)