### PR TITLE
Aggiunge download magazzino in formato Excel/CSV

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ funzionalità per la gestione di clienti, ticket, riparazioni e magazzino.
 """
 
 import json
+import csv
+import io
 import os
 import sqlite3
 import uuid
@@ -665,6 +667,66 @@ def create_app(test_config: Optional[Mapping[str, Any]] = None) -> Flask:
             edit_item=edit_item,
             low_stock_ids=low_stock_ids,
             total_quantity=total_quantity,
+        )
+
+    @app.route('/magazzino/export', methods=['GET'])
+    @login_required
+    def export_magazzino():
+        db = get_db()
+        search_query = (request.args.get('q') or '').strip()
+
+        params: List[str] = []
+        query = (
+            'SELECT code, name, quantity, minimum_quantity, location, category, '
+            'description, notes, created_at, updated_at '
+            'FROM inventory_items'
+        )
+        if search_query:
+            like = f'%{search_query}%'
+            query += (
+                ' WHERE code LIKE ? OR name LIKE ? OR '
+                'IFNULL(description, "") LIKE ? OR IFNULL(location, "") LIKE ? OR '
+                'IFNULL(category, "") LIKE ? OR IFNULL(notes, "") LIKE ?'
+            )
+            params.extend([like, like, like, like, like, like])
+        query += ' ORDER BY LOWER(name), LOWER(code)'
+
+        rows = db.execute(query, params).fetchall()
+
+        output = io.StringIO()
+        writer = csv.writer(output, delimiter=';')
+        writer.writerow([
+            'Codice',
+            'Nome',
+            'Quantità',
+            'Scorta minima',
+            'Posizione',
+            'Categoria',
+            'Descrizione',
+            'Note',
+            'Creato il',
+            'Aggiornato il',
+        ])
+        for row in rows:
+            writer.writerow([
+                row['code'],
+                row['name'],
+                row['quantity'],
+                row['minimum_quantity'],
+                row['location'] or '',
+                row['category'] or '',
+                row['description'] or '',
+                row['notes'] or '',
+                row['created_at'] or '',
+                row['updated_at'] or '',
+            ])
+
+        csv_bytes = io.BytesIO(output.getvalue().encode('utf-8-sig'))
+        return send_file(
+            csv_bytes,
+            mimetype='text/csv; charset=utf-8',
+            as_attachment=True,
+            download_name='magazzino.csv',
         )
 
     @app.route('/admin/users')

--- a/templates/magazzino.html
+++ b/templates/magazzino.html
@@ -104,6 +104,9 @@
         <a class="button secondary" href="{{ url_for('magazzino') }}">Azzera</a>
     {% endif %}
 </form>
+<p>
+    <a class="button secondary" href="{{ url_for('export_magazzino', q=search_query or None) }}">Scarica Excel/CSV</a>
+</p>
 {% set is_admin = current_user.is_admin if current_user.is_authenticated else False %}
 {% if is_admin %}
 <div class="inventory-layout">

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -23,6 +23,41 @@ def test_magazzino_available_for_admin(client, login):
     assert b'Nuovo articolo' in response.data
 
 
+def test_magazzino_export_csv_requires_authentication(client):
+    response: Response = client.get('/magazzino/export')
+    assert response.status_code == 302
+    assert '/auth/login' in response.headers.get('Location', '')
+
+
+def test_magazzino_export_csv_includes_items_and_filter(client, app, login):
+    login('admin', 'adminpass')
+    with app.app_context():
+        db = get_db()
+        db.execute(
+            'INSERT INTO inventory_items (code, name, quantity, minimum_quantity, location, category, description, notes) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            ('ABC-001', 'Alimentatore', 5, 2, 'A1', 'Ricambi', '65W USB-C', 'Test export'),
+        )
+        db.execute(
+            'INSERT INTO inventory_items (code, name, quantity, minimum_quantity, location, category, description, notes) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            ('XYZ-999', 'Mouse', 10, 1, 'B2', 'Periferiche', 'Wireless', 'Non filtrato'),
+        )
+        db.commit()
+
+    response: Response = client.get('/magazzino/export?q=ABC')
+    assert response.status_code == 200
+    assert response.mimetype == 'text/csv'
+    disposition = response.headers.get('Content-Disposition', '')
+    assert 'attachment' in disposition
+    assert 'magazzino.csv' in disposition
+
+    body = response.get_data(as_text=True)
+    assert 'Codice;Nome;Quantità;Scorta minima' in body
+    assert 'ABC-001;Alimentatore;5;2;A1;Ricambi;65W USB-C;Test export' in body
+    assert 'XYZ-999;Mouse' not in body
+
+
 def test_navigation_shows_magazzino_and_calendar_links(client):
     response: Response = client.get('/auth/login')
     assert response.status_code == 200


### PR DESCRIPTION
### Motivation
- Fornire la capacità di scaricare l'elenco articoli di magazzino in un formato apribile da Excel/Google Fogli, rispettando il filtro di ricerca già disponibile nella pagina Magazzino.

### Description
- Aggiunta la rotta protetta `GET /magazzino/export` che estrae gli articoli da `inventory_items` e genera un CSV con separatore `;` e BOM `utf-8-sig` per compatibilità Excel.
- L'export rispetta il parametro di filtro `q` e ordina i risultati come la pagina di elenco; l'implementazione usa i nuovi import `csv` e `io` in `app.py`.
- Aggiunto un pulsante `Scarica Excel/CSV` nella vista `templates/magazzino.html` che richiama la rotta di export con il filtro corrente.
- Aggiunti test in `tests/test_pages.py` per verificare che l'export richieda autenticazione e che il CSV contenga i dati corretti rispettando il filtro.

### Testing
- Eseguito `pytest -q tests/test_pages.py::test_magazzino_export_csv_requires_authentication tests/test_pages.py::test_magazzino_export_csv_includes_items_and_filter tests/test_pages.py::test_magazzino_available_for_admin` e tutti i test sono passati (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b018c0f9e4832d801fa80ed029d8a0)